### PR TITLE
Fix for issue #258: toEqual goes into infinite recursion for cyclic data

### DIFF
--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -71,6 +71,102 @@
     }
 
     /**
+     * Used to convert an array to an arguments object.
+     */
+    function gather() { return arguments; }
+
+    /**
+     * Make a deep copy of an object or array, assuring that there is at
+     * most one instance of each object or array in the resulting structure.
+     * The duplicate references (which might be forming cycles) are
+     * replaced with an object of the form
+     *       {$ref: PATH}
+     * where the PATH is a JSONPath string that locates the first occurance.
+     * So,
+     *       var a = [];
+     *       a[0] = a;
+     *       return JSON.stringify(JSON.decycle(a));
+     *  produces the string '[{"$ref":"$"}]'.
+     *
+     *  JSONPath is used to locate the unique object. $ indicates the top
+     *  level of the object or array. [NUMBER] or [STRING] indicates a child
+     *  member or property.
+     * 
+     *  This function is copied from:
+     *      https://github.com/douglascrockford/JSON-js->cyclic.js 
+     */
+    function decycle(object) {
+        'use strict';
+
+        var objects = [],   // Keep a reference to each unique object or array
+            paths = [];     // Keep the path to each unique object or array
+
+        return (function derez(value, path) {
+
+            // The derez recurses through the object, producing the deep copy.
+
+            var i,          // The loop counter
+                name,       // Property name
+                nu;         // The new object or array
+
+            // typeof null === 'object', so go on if this value is really an
+            // object but not one of the weird builtin objects.
+
+            if (typeof value === 'object' && value !== null &&
+                    !(value instanceof Boolean) &&
+                    !(value instanceof Date)    &&
+                    !(value instanceof Number)  &&
+                    !(value instanceof RegExp)  &&
+                    !(value instanceof String)) {
+
+                // If the value is an object or array, look to see if we have
+                // already encountered it. If so, return a $ref/path object.
+                // This is a hard way, linear search that will get slower as
+                // the number of unique objects grows.
+
+                for (i = 0; i < objects.length; i += 1) {
+                    if (objects[i] === value) {
+                        return {$ref: paths[i]};
+                    }
+                }
+
+                // Otherwise, accumulate the unique value and its path.
+
+                objects.push(value);
+                paths.push(path);
+
+                // If it is an array, replicate the array.
+
+                // Different from the original implementation is an arguments
+                // object now treated as an array and finally converted back
+                // to an arguments object.
+                // Further are custom properties of an array copied now.
+                if (Object.prototype.toString.apply(value)
+                        === '[object Array]' || _.isArguments(value)) {
+                    nu = [];
+                } else {
+                    nu = {};
+                }
+
+                for (name in value) {
+                    if (Object.prototype.hasOwnProperty.call(value, name)) {
+                        nu[name] = derez(value[name],
+                            path + '[' + JSON.stringify(name) + ']');
+                    }
+                }
+
+                // Convert array back to an arguments object.
+                if (_.isArguments(value)) {
+                    nu = gather.apply(null, nu);
+                }
+
+                return nu;
+            }
+            return value;
+        }(object, '$'));
+    }
+
+    /**
      * @name samsam.deepEqual
      * @param Object obj1
      * @param Object obj2
@@ -204,7 +300,9 @@
         isElement: isElement,
         isNegZero: isNegZero,
         identical: identical,
-        deepEqual: deepEqual,
+        deepEqual: function (obj1, obj2) {
+            return deepEqual(decycle(obj1), decycle(obj2));
+        },
         match: match
     };
 });

--- a/test/samsam-test.js
+++ b/test/samsam-test.js
@@ -168,6 +168,32 @@ if (typeof module === "object" && typeof require === "function") {
 
         pass("arguments to array like object",
              arrayLike, gather(1, 2, {}, []));
+
+        var cyclic1 = {}, cyclic2 = {};
+        cyclic1.ref = cyclic1;
+        cyclic2.ref = cyclic2;
+        pass("equal cyclic objects (cycle on 2nd level)", cyclic1, cyclic2);
+
+        var cyclic3 = {}, cyclic4 = {};
+        cyclic3.ref = cyclic3;
+        cyclic4.ref = cyclic4;
+        cyclic4.ref2 = cyclic4;
+        fail("different cyclic objects (cycle on 2nd level)", cyclic3, cyclic4);
+
+        var cyclic5 = {}, cyclic6 = {};
+        cyclic5.ref = {};
+        cyclic5.ref.ref = cyclic5;
+        cyclic6.ref = {};
+        cyclic6.ref.ref = cyclic6;
+        pass("equal cyclic objects (cycle on 3rd level)", cyclic5, cyclic6);
+
+        var cyclic7 = {}, cyclic8 = {};
+        cyclic7.ref = {};
+        cyclic7.ref.ref = cyclic7;
+        cyclic8.ref = {};
+        cyclic8.ref.ref = cyclic8;
+        cyclic8.ref.ref2 = cyclic8;
+        fail("different cyclic objects (cycle on 3rd level)", cyclic7, cyclic8);
     });
 
     tests("match", function (pass, fail, shouldThrow, add) {
@@ -263,4 +289,5 @@ if (typeof module === "object" && typeof require === "function") {
         fail("mis-matching array 'subset'", [1, 2, 3], [2, 3, 4]);
         fail("mis-ordered array 'subset'", [1, 2, 3], [1, 3]);
     });
+
 }());


### PR DESCRIPTION
This is my suggestion for solving the cyclic data issue:

The data is decycled before comparision.

The function for decycling the data is copied from [cycle.js](https://github.com/douglascrockford/JSON-js/blob/master/cycle.js) from [douglascrockford/JSON-js](https://github.com/douglascrockford/JSON-js).
I had to make a few changes to it, so that it meets our needs.
