### PR TITLE
New version of cyclic comparison

### DIFF
--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -118,103 +118,6 @@
         }
     }
 
-    /**
-     * Used to convert an array to an arguments object.
-     */
-    function gather() { return arguments; }
-
-    /**
-     * Make a deep copy of an object or array, assuring that there is at
-     * most one instance of each object or array in the resulting structure.
-     * The duplicate references (which might be forming cycles) are
-     * replaced with an object of the form
-     *       {$ref: PATH}
-     * where the PATH is a JSONPath string that locates the first occurance.
-     * So,
-     *       var a = [];
-     *       a[0] = a;
-     *       return JSON.stringify(JSON.decycle(a));
-     *  produces the string '[{"$ref":"$"}]'.
-     *
-     *  JSONPath is used to locate the unique object. $ indicates the top
-     *  level of the object or array. [NUMBER] or [STRING] indicates a child
-     *  member or property.
-     *
-     *  This function is copied from:
-     *      https://github.com/douglascrockford/JSON-js->cyclic.js
-     */
-    function decycle(object) {
-        'use strict';
-
-        var objects = [],   // Keep a reference to each unique object or array
-            paths = [];     // Keep the path to each unique object or array
-
-        return (function derez(value, path) {
-
-            // The derez recurses through the object, producing the deep copy.
-
-            var i,          // The loop counter
-                name,       // Property name
-                nu;         // The new object or array
-
-            // typeof null === 'object', so go on if this value is really an
-            // object but not one of the weird builtin objects.
-
-            if (typeof value === 'object' && value !== null &&
-                    !(value instanceof Boolean) &&
-                    !(value instanceof Date)    &&
-                    !(value instanceof Number)  &&
-                    !(value instanceof RegExp)  &&
-                    !(value instanceof String)) {
-
-                // If the value is an object or array, look to see if we have
-                // already encountered it. If so, return a $ref/path object.
-                // This is a hard way, linear search that will get slower as
-                // the number of unique objects grows.
-
-                for (i = 0; i < objects.length; i += 1) {
-                    if (objects[i] === value) {
-                        return {$ref: paths[i]};
-                    }
-                }
-
-                // Otherwise, accumulate the unique value and its path.
-
-                objects.push(value);
-                paths.push(path);
-
-                // If it is an array, replicate the array.
-
-                // Different from the original implementation is an arguments
-                // object now treated as an array and finally converted back
-                // to an arguments object.
-                // Further are custom properties of an array copied now.
-                if (Object.prototype.toString.apply(value)
-                        === '[object Array]' || isArguments(value)) {
-                    nu = [];
-                } else {
-                    nu = {};
-                }
-
-                for (name in value) {
-                    if (Object.prototype.hasOwnProperty.call(value, name)) {
-                        nu[name] = derez(
-                            value[name],
-                            path + '[' + JSON.stringify(name) + ']'
-                        );
-                    }
-                }
-
-                // Convert array back to an arguments object.
-                if (isArguments(value)) {
-                    nu = gather.apply(null, nu);
-                }
-
-                return nu;
-            }
-            return value;
-        }(object, '$'));
-    }
 
     /**
      * @name samsam.deepEqual
@@ -228,58 +131,173 @@
      *   - They are both arrays containing elements that are all deepEqual
      *   - They are objects with the same set of properties, and each property
      *     in ``obj1`` is deepEqual to the corresponding property in ``obj2``
+     * 
+     * Supports cyclic objects.
      */
-    function deepEqual(obj1, obj2) {
-        var type1 = typeof obj1;
-        var type2 = typeof obj2;
+    function deepEqualCyclic(obj1, obj2) {
 
-        // == null also matches undefined
-        if (obj1 === obj2 ||
-                isNaN(obj1) || isNaN(obj2) ||
-                obj1 == null || obj2 == null ||
-                type1 !== "object" || type2 !== "object") {
-            return identical(obj1, obj2);
-        }
+        // used for cyclic comparison
+        // contain already visited objects
+        var objects1 = [],
+            objects2 = [],
+        // contain pathes (position in the object structure)
+        // of the already visited objects
+        // indexes same as in objects arrays    
+            paths1 = [],
+            paths2 = [],
+        // contains combinations of already compared objects
+        // in the manner: { "$1['ref']$2['ref']": true }
+            compared = {};
 
-        // Elements are only equal if identical(expected, actual)
-        if (isElement(obj1) || isElement(obj2)) { return false; }
+        /**
+         * used to check, if the value of a property is an object
+         * (cyclic logic is only needed for objects)
+         * only needed for cyclic logic
+         */
+        function isObject(value) {
 
-        var isDate1 = isDate(obj1), isDate2 = isDate(obj2);
-        if (isDate1 || isDate2) {
-            if (!isDate1 || !isDate2 || obj1.getTime() !== obj2.getTime()) {
-                return false;
+            if (typeof value === 'object' && value !== null &&
+                    !(value instanceof Boolean) &&
+                    !(value instanceof Date)    &&
+                    !(value instanceof Number)  &&
+                    !(value instanceof RegExp)  &&
+                    !(value instanceof String)) {
+
+                return true;
             }
+
+            return false;
         }
 
-        if (obj1 instanceof RegExp && obj2 instanceof RegExp) {
-            if (obj1.toString() !== obj2.toString()) { return false; }
-        }
+        /**
+         * returns the index of the given object in the
+         * given objects array, -1 if not contained
+         * only needed for cyclic logic
+         */
+        function getIndex(objects, obj) {
 
-        var class1 = getClass(obj1);
-        var class2 = getClass(obj2);
-        var keys1 = keys(obj1);
-        var keys2 = keys(obj2);
-
-        if (isArguments(obj1) || isArguments(obj2)) {
-            if (obj1.length !== obj2.length) { return false; }
-        } else {
-            if (type1 !== type2 || class1 !== class2 ||
-                    keys1.length !== keys2.length) {
-                return false;
+            var i;
+            for (i = 0; i < objects.length; i++) {
+                if (objects[i] === obj) {
+                    return i;
+                }
             }
+
+            return -1;
         }
 
-        var key, i, l;
+        // does the recursion for the deep equal check
+        return (function deepEqual(obj1, obj2, path1, path2) {
+            var type1 = typeof obj1;
+            var type2 = typeof obj2;
 
-        for (i = 0, l = keys1.length; i < l; i++) {
-            key = keys1[i];
-            if (!o.hasOwnProperty.call(obj2, key) ||
-                    !deepEqual(obj1[key], obj2[key])) {
-                return false;
+            // == null also matches undefined
+            if (obj1 === obj2 ||
+                    isNaN(obj1) || isNaN(obj2) ||
+                    obj1 == null || obj2 == null ||
+                    type1 !== "object" || type2 !== "object") {
+
+                return identical(obj1, obj2);
             }
-        }
 
-        return true;
+            // Elements are only equal if identical(expected, actual)
+            if (isElement(obj1) || isElement(obj2)) { return false; }
+
+            var isDate1 = isDate(obj1), isDate2 = isDate(obj2);
+            if (isDate1 || isDate2) {
+                if (!isDate1 || !isDate2 || obj1.getTime() !== obj2.getTime()) {
+                    return false;
+                }
+            }
+
+            if (obj1 instanceof RegExp && obj2 instanceof RegExp) {
+                if (obj1.toString() !== obj2.toString()) { return false; }
+            }
+
+            var class1 = getClass(obj1);
+            var class2 = getClass(obj2);
+            var keys1 = keys(obj1);
+            var keys2 = keys(obj2);
+
+            if (isArguments(obj1) || isArguments(obj2)) {
+                if (obj1.length !== obj2.length) { return false; }
+            } else {
+                if (type1 !== type2 || class1 !== class2 ||
+                        keys1.length !== keys2.length) {
+                    return false;
+                }
+            }
+
+            var key, i, l,
+                // following vars are used for the cyclic logic
+                value1, value2,
+                isObject1, isObject2,
+                index1, index2,
+                newPath1, newPath2;
+
+            for (i = 0, l = keys1.length; i < l; i++) {
+                key = keys1[i];
+                if (!o.hasOwnProperty.call(obj2, key)) {
+                    return false;
+                }
+
+                // Start of the cyclic logic
+
+                value1 = obj1[key];
+                value2 = obj2[key];
+
+                isObject1 = isObject(value1);
+                isObject2 = isObject(value2);
+
+                // determine, if the objects were already visited
+                // (it's faster to check for isObject first, than to
+                // get -1 from getIndex for non objects)
+                index1 = isObject1 ? getIndex(objects1, value1) : -1;
+                index2 = isObject2 ? getIndex(objects2, value2) : -1;
+
+                // determine the new pathes of the objects
+                // - for non cyclic objects the current path will be extended
+                //   by current property name
+                // - for cyclic objects the stored path is taken
+                newPath1 = index1 !== -1
+                    ? paths1[index1]
+                    : path1 + '[' + JSON.stringify(key) + ']';
+                newPath2 = index2 !== -1
+                    ? paths2[index2]
+                    : path2 + '[' + JSON.stringify(key) + ']';
+
+                // stop recursion if current objects are already compared
+                if (compared[newPath1 + newPath2]) {
+                    return true;
+                }
+
+                // remember the current objects and their pathes 
+                if (index1 === -1 && isObject1) {
+                    objects1.push(value1);
+                    paths1.push(newPath1);
+                }
+                if (index2 === -1 && isObject2) {
+                    objects2.push(value2);
+                    paths2.push(newPath2);
+                }
+
+                // remember that the current objects are already compared
+                if (isObject1 && isObject2) {
+                    compared[newPath1 + newPath2] = true;
+                }
+
+                // End of cyclic logic
+
+                // neither value1 nor value2 is a cycle
+                // continue with next level
+                if (!deepEqual(value1, value2, newPath1, newPath2)) {
+                    return false;
+                }
+            }
+
+            return true;
+
+        }(obj1, obj2, '$1', '$2'));
     }
 
     var match;
@@ -352,9 +370,7 @@
         isDate: isDate,
         isNegZero: isNegZero,
         identical: identical,
-        deepEqual: function (obj1, obj2) {
-            return deepEqual(decycle(obj1), decycle(obj2));
-        },
+        deepEqual: deepEqualCyclic,
         match: match
     };
 });

--- a/test/samsam-test.js
+++ b/test/samsam-test.js
@@ -89,12 +89,12 @@ if (typeof module === "object" && typeof require === "function") {
         fail("date with different custom properties", date, sameDateWithProp);
         fail("strings and numbers with coercion", "4", 4);
         fail("numbers and strings with coercion", 4, "4");
-        fail("number object with coercion", 32, Number(32));
-        fail("number object reverse with coercion", Number(32), 32);
+        fail("number object with coercion", 32, new Number(32));
+        fail("number object reverse with coercion", new Number(32), 32);
         fail("falsy values with coercion", 0, "");
         fail("falsy values reverse with coercion", "", 0);
-        fail("string boxing with coercion", "4", String("4"));
-        fail("string boxing reverse with coercion", String("4"), "4");
+        fail("string boxing with coercion", "4", new String("4"));
+        fail("string boxing reverse with coercion", new String("4"), "4");
         pass("NaN to NaN", NaN, NaN);
         fail("-0 to +0", -0, +0);
         fail("-0 to 0", -0, 0);
@@ -168,32 +168,81 @@ if (typeof module === "object" && typeof require === "function") {
 
         pass("arguments to array like object",
              arrayLike, gather(1, 2, {}, []));
+    });
 
-        var cyclic1 = {}, cyclic2 = {};
-        cyclic1.ref = cyclic1;
-        cyclic2.ref = cyclic2;
-        pass("equal cyclic objects (cycle on 2nd level)", cyclic1, cyclic2);
+    /**
+     * Tests for cyclic objects.
+     */
+    tests("deepEqual", function (pass, fail) {
 
-        var cyclic3 = {}, cyclic4 = {};
-        cyclic3.ref = cyclic3;
-        cyclic4.ref = cyclic4;
-        cyclic4.ref2 = cyclic4;
-        fail("different cyclic objects (cycle on 2nd level)", cyclic3, cyclic4);
+        (function () {
+            var cyclic1 = {}, cyclic2 = {};
+            cyclic1.ref = cyclic1;
+            cyclic2.ref = cyclic2;
+            pass("equal cyclic objects (cycle on 2nd level)", cyclic1, cyclic2);
+        }());
 
-        var cyclic5 = {}, cyclic6 = {};
-        cyclic5.ref = {};
-        cyclic5.ref.ref = cyclic5;
-        cyclic6.ref = {};
-        cyclic6.ref.ref = cyclic6;
-        pass("equal cyclic objects (cycle on 3rd level)", cyclic5, cyclic6);
+        (function () {
+            var cyclic1 = {}, cyclic2 = {};
+            cyclic1.ref = cyclic1;
+            cyclic2.ref = cyclic2;
+            cyclic2.ref2 = cyclic2;
+            fail("different cyclic objects (cycle on 2nd level)",
+                cyclic1, cyclic2);
+        }());
 
-        var cyclic7 = {}, cyclic8 = {};
-        cyclic7.ref = {};
-        cyclic7.ref.ref = cyclic7;
-        cyclic8.ref = {};
-        cyclic8.ref.ref = cyclic8;
-        cyclic8.ref.ref2 = cyclic8;
-        fail("different cyclic objects (cycle on 3rd level)", cyclic7, cyclic8);
+        (function () {
+            var cyclic1 = {}, cyclic2 = {};
+            cyclic1.ref = {};
+            cyclic1.ref.ref = cyclic1;
+            cyclic2.ref = {};
+            cyclic2.ref.ref = cyclic2;
+            pass("equal cyclic objects (cycle on 3rd level)", cyclic1, cyclic2);
+        }());
+
+        (function () {
+            var cyclic1 = {}, cyclic2 = {};
+            cyclic1.ref = {};
+            cyclic1.ref.ref = cyclic1;
+            cyclic2.ref = {};
+            cyclic2.ref.ref = cyclic2;
+            cyclic2.ref.ref2 = cyclic2;
+            fail("different cyclic objects (cycle on 3rd level)",
+                cyclic1, cyclic2);
+        }());
+
+        (function () {
+            var cyclic1 = {}, cyclic2 = {};
+            cyclic1.ref = cyclic1;
+            cyclic2.ref = cyclic1;
+            pass("equal objects even though only one object is cyclic",
+                cyclic1, cyclic2);
+        }());
+
+        (function () {
+            var cyclic1 = {}, cyclic2 = {};
+            cyclic1.ref = {
+                ref: cyclic1
+            };
+            cyclic2.ref = {};
+            cyclic2.ref.ref = cyclic2.ref;
+            pass("referencing different but equal cyclic objects",
+                cyclic1, cyclic2);
+        }());
+
+        (function () {
+            var cyclic1 = {a: "a"}, cyclic2 = {a: "a"};
+            cyclic1.ref = {
+                b: "b",
+                ref: cyclic1
+            };
+            cyclic2.ref = {
+                b: "b"
+            };
+            cyclic2.ref.ref = cyclic2.ref;
+            fail("referencing different and unequal cyclic objects",
+                cyclic1, cyclic2);
+        }());
     });
 
     tests("match", function (pass, fail, shouldThrow, add) {


### PR DESCRIPTION
I have completely changed the logic for comparing cyclic objects. The first approach, decycling the objects before comparison, wasn't viable for some tricky cases.

For example:

``` javascript
var cyclic1 = {}, cyclic2 = {};
cyclic1.ref = cyclic1;
cyclic2.ref = cyclic1;
pass("equal objects even though only one object is cyclic", cyclic1, cyclic2);
```

That test didn't pass before, but should, because of `cyclic1.ref === cyclic2.ref`.

Now the cycle detection is made during the comparison. Besides the information which objects were already visited the new implementation stores the information which combinations of objects (including nested objects) were already compared. An already compared combination terminates the recursion.

I made a lot of comments for a better understanding of the logic. That's normally not a good style. But for the moment i hope it is ok.

I am also not really satisfied with the structure of the tests for the cyclic logic. They are hard to read. Maybe somebody has a good idea how we could improve them.

Further i would be delighted, if somebody adds some more tests. I am quite sure, that i haven't considered all cases.

Due to the fact, that the cycle detection takes time and therefore slows down the comparison, we should think about making  the cyclic comparison configurable. By default the comparison would be without cycle detection. You have to activate it in the test via `this.cycleDetection=true`, as for setting another timeout value.
