### PR TITLE
Make `isArguments` work with arguments from `"strict mode"` functions

### DIFF
--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -29,6 +29,7 @@
      * ``false`` otherwise.
      */
     function isArguments(object) {
+        if (getClass(object) === 'Arguments') { return true; }
         if (typeof object !== "object" || typeof object.length !== "number" ||
                 getClass(object) === "Array") {
             return false;

--- a/test/samsam-test.js
+++ b/test/samsam-test.js
@@ -341,4 +341,11 @@ if (typeof module === "object" && typeof require === "function") {
         pass("objects with empty arrays", { xs: [] }, { xs: [] });
     });
 
+    tests("isArguments", function (pass, fail) {
+        pass("arguments object", arguments);
+        fail("primitive", 42);
+        fail("object", {});
+        pass("arguments object from strict-mode function",
+          (function() { "use strict"; return arguments; }()));
+    });
 }());


### PR DESCRIPTION
Adds some tests for `isArguments` and lets it work with arguments objects coming from `"strict mode"` functions.
