### PR TITLE
if two objects are strictly equal, then they are the same object

### DIFF
--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -348,6 +348,14 @@
             return matcher === object;
         }
 
+        if (typeof(matcher) === "undefined") {
+            return typeof(object) === "undefined";
+        }
+
+        if (matcher === null) {
+            return object === null;
+        }
+
         if (getClass(object) === "Array" && getClass(matcher) === "Array") {
             return arrayContains(object, matcher);
         }

--- a/test/samsam-test.js
+++ b/test/samsam-test.js
@@ -367,6 +367,13 @@ if (typeof module === "object" && typeof require === "function") {
 
         var obj = { foo: undefined };
         pass("same object matches self", obj, obj);
+
+        pass("null matches null", null, null);
+        fail("null does not match undefined", null, undefined);
+
+        pass("undefined matches undefined", undefined, undefined);
+        fail("undefined does not match null", undefined, null);
+
     });
 
     tests("isArguments", function (pass, fail) {


### PR DESCRIPTION
This fixes https://github.com/busterjs/buster/issues/64 - the elements have some properties which are declared, but undefined. Since there was no check for object sameness, and there is no defined behaviour if `samsam.match(undefined, undefined)` an element was considered non-matching to itself.

Speaking of `undefined`... does it "match" `undefined`? IMHO yes - and I can PR that as well...
