### PR TITLE
Allow `undefined` and `null` properties to be matched

### DIFF
--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -360,7 +360,7 @@
                         typeof object.getAttribute === "function") {
                     value = object.getAttribute(prop);
                 }
-                if (typeof value === "undefined" || !match(value, matcher[prop])) {
+                if (value !== matcher[prop] && (typeof value === "undefined" || !match(value, matcher[prop]))) {
                     return false;
                 }
             }

--- a/test/samsam-test.js
+++ b/test/samsam-test.js
@@ -357,6 +357,10 @@ if (typeof module === "object" && typeof require === "function") {
                 }
             }
         }, { "data-path": "foo.bar" });
+
+        pass("equal null properties", { foo: null }, { foo: null });
+        fail("unmatched null property", {}, { foo: null });
+        pass("equal undefined properties", { foo: undefined }, { foo: undefined });
     });
 
     tests("isArguments", function (pass, fail) {


### PR DESCRIPTION
This allows matcher object to also specify properties that are `null` or `undefined`. It does not allow `null` or `undefined` to be passed as matchers.
