### PR TITLE
Ensure deepEqual and match always return true/false

### DIFF
--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -101,7 +101,7 @@ function identical(obj1, obj2) {
         return obj1 !== 0 || isNegZero(obj1) === isNegZero(obj2);
     }
 
-    return undefined;
+    return false;
 }
 
 function isSet(val) {
@@ -109,7 +109,7 @@ function isSet(val) {
         return true;
     }
 
-    return undefined;
+    return false;
 }
 
 function isSubset(s1, s2, compare) {

--- a/lib/samsam.test.js
+++ b/lib/samsam.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var assert = require("assert");
+var assert = require("@sinonjs/referee").assert;
 require("jsdom-global")();
 var samsam = require("./samsam");
 
@@ -9,7 +9,7 @@ describe("isElement", function () {
         if (typeof document !== "undefined") {
             var element = document.createElement("div");
             var checkElement = samsam.isElement(element);
-            assert.strictEqual(checkElement, true);
+            assert.isTrue(checkElement);
         }
     });
 
@@ -17,41 +17,41 @@ describe("isElement", function () {
         if (typeof document !== "undefined") {
             var element = document.createTextNode("Hello");
             var checkElement = samsam.isElement(element);
-            assert.strictEqual(checkElement, false);
+            assert.isFalse(checkElement);
         }
     });
 
     it("returns false if node like object", function () {
         var nodeLike = { nodeType: 1 };
         var checkElement = samsam.isElement(nodeLike);
-        assert.strictEqual(checkElement, false);
+        assert.isFalse(checkElement);
     });
 
     it("returns false if number", function () {
         var checkElement = samsam.isElement(42);
-        assert.strictEqual(checkElement, false);
+        assert.isFalse(checkElement);
     });
 
     it("returns false if object", function () {
         var checkElement = samsam.isElement({});
-        assert.strictEqual(checkElement, false);
+        assert.isFalse(checkElement);
     });
 });
 
 describe("isArguments", function () {
     it("returns true if arguments is an object", function () {
         var checkArgs = samsam.isArguments(arguments);
-        assert.strictEqual(checkArgs, true);
+        assert.isTrue(checkArgs);
     });
 
     it("returns false if number", function () {
         var checkArgs = samsam.isArguments(24);
-        assert.strictEqual(checkArgs, false);
+        assert.isFalse(checkArgs);
     });
 
     it("returns false if empty object", function () {
         var checkArgs = samsam.isArguments({});
-        assert.strictEqual(checkArgs, false);
+        assert.isFalse(checkArgs);
     });
 
     it("returns true if arguments object from strict-mode function", function () {
@@ -59,29 +59,29 @@ describe("isArguments", function () {
             return arguments;
         };
         var checkArgs = samsam.isArguments(returnArgs());
-        assert.strictEqual(checkArgs, true);
+        assert.isTrue(checkArgs);
     });
 });
 
 describe("isNegZero", function () {
     it("returns true if negative zero", function () {
         var checkZero = samsam.isNegZero(-0);
-        assert.strictEqual(checkZero, true);
+        assert.isTrue(checkZero);
     });
 
     it("returns false if zero", function () {
         var checkZero = samsam.isNegZero(0);
-        assert.strictEqual(checkZero, false);
+        assert.isFalse(checkZero);
     });
 
     it("returns false if object", function () {
         var checkZero = samsam.isNegZero({});
-        assert.strictEqual(checkZero, false);
+        assert.isFalse(checkZero);
     });
 
     it("returns false if String", function () {
         var checkZero = samsam.isNegZero("-0");
-        assert.strictEqual(checkZero, false);
+        assert.isFalse(checkZero);
     });
 });
 
@@ -89,28 +89,28 @@ describe("identical", function () {
     it("returns true if strings are identical", function () {
         var str = "string";
         var checkIdent = samsam.identical(str, str);
-        assert.strictEqual(checkIdent, true);
+        assert.isTrue(checkIdent);
     });
 
     it("returns true if objects are identical", function () {
         var obj = { id: 42 };
         var checkIdent = samsam.identical(obj, obj);
-        assert.strictEqual(checkIdent, true);
+        assert.isTrue(checkIdent);
     });
 
     it("returns true if NaN", function () {
         var checkIdent = samsam.identical(NaN, NaN);
-        assert.strictEqual(checkIdent, true);
+        assert.isTrue(checkIdent);
     });
 
     it("returns false if equal but different type", function () {
         var checkIdent = samsam.identical(0, "0");
-        assert.strictEqual(checkIdent, false);
+        assert.isFalse(checkIdent);
     });
 
     it("returns false on -0 and 0", function () {
         var checkIdent = samsam.identical(0, -0);
-        assert.strictEqual(checkIdent, false);
+        assert.isFalse(checkIdent);
     });
 });
 
@@ -125,131 +125,131 @@ describe("deepEqual", function () {
 
     it("returns true if object to itself", function () {
         var checkDeep = samsam.deepEqual(obj, obj);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if strings", function () {
         var checkDeep = samsam.deepEqual("string", "string");
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if numbers", function () {
         var checkDeep = samsam.deepEqual(32, 32);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if boolean", function () {
         var checkDeep = samsam.deepEqual(false, false);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if null", function () {
         var checkDeep = samsam.deepEqual(null, null);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if undefined", function () {
         var checkDeep = samsam.deepEqual(undefined, undefined);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if function to itself", function () {
         var checkDeep = samsam.deepEqual(func, func);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns false if different functions", function () {
         var checkDeep = samsam.deepEqual(function () {}, function () {});
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns true if array to itself", function () {
         var checkDeep = samsam.deepEqual(arr, arr);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if date objects with same date", function () {
         var checkDeep = samsam.deepEqual(date, sameDate);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns false if date objects with different dates", function () {
         var checkDeep = samsam.deepEqual(date, sameDateWithProp);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if strings and numbers with coercion", function () {
         var checkDeep = samsam.deepEqual("4", 4);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if numbers and strings with coercion", function () {
         var checkDeep = samsam.deepEqual(4, "4");
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if number object with coercion", function () {
         // eslint-disable-next-line no-new-wrappers
         var checkDeep = samsam.deepEqual(32, new Number(32));
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if number object reverse with coercion", function () {
         // eslint-disable-next-line no-new-wrappers
         var checkDeep = samsam.deepEqual(new Number(32), 32);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if falsy values with coercion", function () {
         var checkDeep = samsam.deepEqual(0, "");
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if falsy values reverse with coercion", function () {
         var checkDeep = samsam.deepEqual("", 0);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if string boxing with coercion", function () {
         // eslint-disable-next-line no-new-wrappers
         var checkDeep = samsam.deepEqual("4", new String("4"));
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if string boxing reverse with coercion", function () {
         // eslint-disable-next-line no-new-wrappers
         var checkDeep = samsam.deepEqual(new String("4"), "4");
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns true if NaN to Nan", function () {
         var checkDeep = samsam.deepEqual(NaN, NaN);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns false if -0 to +0", function () {
         var checkDeep = samsam.deepEqual(+0, -0);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if -0 to 0", function () {
         var checkDeep = samsam.deepEqual(-0, 0);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if objects with different own properties", function () {
         var checkDeep = samsam.deepEqual({ id: 42 }, { id: 42, di: 24 });
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if objects with different own properties values", function () {
         var checkDeep = samsam.deepEqual({ id: 42 }, { id: undefined });
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if objects with one property with different values", function () {
         var checkDeep = samsam.deepEqual({ id: 42 }, { id: 24 });
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns true if complex objects", function () {
@@ -270,7 +270,7 @@ describe("deepEqual", function () {
             id: 42,
             name: "Hey"
         });
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if arrays", function () {
@@ -278,12 +278,12 @@ describe("deepEqual", function () {
             [1, 2, "Hey there", func, { id: 42, prop: [2, 3] }],
             [1, 2, "Hey there", func, { id: 42, prop: [2, 3] }]
         );
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns false if nested array with shallow array", function () {
         var checkDeep = samsam.deepEqual([["hey"]], ["hey"]);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if arrays with different custom properties", function () {
@@ -291,17 +291,17 @@ describe("deepEqual", function () {
         var arr2 = [1, 2, 3];
         arr1.prop = 42;
         var checkDeep = samsam.deepEqual(arr1, arr2);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns true if regexp literals", function () {
         var checkDeep = samsam.deepEqual(/a/, /a/);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if regexp objects", function () {
         var checkDeep = samsam.deepEqual(new RegExp("[a-z]+"), new RegExp("[a-z]+"));
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns false if regexp objects with custom properties", function () {
@@ -309,105 +309,105 @@ describe("deepEqual", function () {
         var re2 = new RegExp("[a-z]+");
         re2.id = 42;
         var checkDeep = samsam.deepEqual(re1, re2);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if different objects", function () {
         var checkDeep = samsam.deepEqual({id: 42}, {});
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if object to null", function () {
         var checkDeep = samsam.deepEqual({}, null);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if object to undefined", function () {
         var checkDeep = samsam.deepEqual({}, undefined);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if object to false", function () {
         var checkDeep = samsam.deepEqual({}, false);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if false to object", function () {
         var checkDeep = samsam.deepEqual(false, {});
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if object to true", function () {
         var checkDeep = samsam.deepEqual({}, true);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if true to object", function () {
         var checkDeep = samsam.deepEqual(true, {});
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if 'empty' object to date", function () {
         var checkDeep = samsam.deepEqual({}, new Date());
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if 'empty' object to string object", function () {
         var checkDeep = samsam.deepEqual({}, String());
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if 'empty' object to number object", function () {
         var checkDeep = samsam.deepEqual({}, Number());
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns false if 'empty' object to empty array", function () {
         var checkDeep = samsam.deepEqual({}, []);
-        assert.strictEqual(checkDeep, false);
+        assert.isFalse(checkDeep);
     });
 
     it("returns true if arguments to array", function () {
         var gather = function () { return arguments; };
         var checkDeep = samsam.deepEqual([1, 2, {}, []], gather(1, 2, {}, []));
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if array to arguments", function () {
         var gather = function () { return arguments; };
         var checkDeep = samsam.deepEqual(gather(), []);
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true if arguments to array like object", function () {
         var gather = function () { return arguments; };
         var arrayLike = { length: 4, "0": 1, "1": 2, "2": {}, "3": [] };
         var checkDeep = samsam.deepEqual(arrayLike, gather(1, 2, {}, []));
-        assert.strictEqual(checkDeep, true);
+        assert.isTrue(checkDeep);
     });
 
     if (typeof Set !== "undefined") {
         it("returns true if set with the same content", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkDeep = samsam.deepEqual(new Set([1, 2, 3]), new Set([2, 1, 3]));
-            assert.strictEqual(checkDeep, true);
+            assert.isTrue(checkDeep);
         });
 
         it("returns false if set with the different content", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkDeep = samsam.deepEqual(new Set([1, 2, 3]), new Set([2, 5, 3]));
-            assert.strictEqual(checkDeep, false);
+            assert.isFalse(checkDeep);
         });
 
         it("returns false on set compared with something else", function () {
             // eslint-disable-next-line ie11/no-collection-args
-            assert.strictEqual(samsam.deepEqual(new Set([1, 2, 3]), "string"), false);
+            assert.isFalse(samsam.deepEqual(new Set([1, 2, 3]), "string"));
             // eslint-disable-next-line ie11/no-collection-args
-            assert.strictEqual(samsam.deepEqual(new Set([1, 2, 3]), false), false);
+            assert.isFalse(samsam.deepEqual(new Set([1, 2, 3]), false));
             // eslint-disable-next-line ie11/no-collection-args
-            assert.strictEqual(samsam.deepEqual(new Set([1, 2, 3]), true), false);
+            assert.isFalse(samsam.deepEqual(new Set([1, 2, 3]), true));
             // eslint-disable-next-line ie11/no-collection-args
-            assert.strictEqual(samsam.deepEqual(new Set([1, 2, 3]), 123), false);
+            assert.isFalse(samsam.deepEqual(new Set([1, 2, 3]), 123));
         });
     }
 
@@ -421,7 +421,7 @@ describe("deepEqual", function () {
             cyclic1.ref = cyclic1;
             cyclic2.ref = cyclic2;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.strictEqual(checkDeep, true);
+            assert.isTrue(checkDeep);
         });
 
         it("returns false if different cyclic objects (cycle on 2nd level)", function () {
@@ -431,7 +431,7 @@ describe("deepEqual", function () {
             cyclic2.ref = cyclic2;
             cyclic2.ref2 = cyclic2;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.strictEqual(checkDeep, false);
+            assert.isFalse(checkDeep);
         });
 
         it("returns true if equal cyclic objects (cycle on 3rd level)", function () {
@@ -442,7 +442,7 @@ describe("deepEqual", function () {
             cyclic2.ref = {};
             cyclic2.ref.ref = cyclic2;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.strictEqual(checkDeep, true);
+            assert.isTrue(checkDeep);
         });
 
         it("returns false if different cyclic objects (cycle on 3rd level)", function () {
@@ -454,7 +454,7 @@ describe("deepEqual", function () {
             cyclic2.ref.ref = cyclic2;
             cyclic2.ref.ref2 = cyclic2;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.strictEqual(checkDeep, false);
+            assert.isFalse(checkDeep);
         });
 
         it("returns true if equal objects even though only one object is cyclic", function () {
@@ -463,7 +463,7 @@ describe("deepEqual", function () {
             cyclic1.ref = cyclic1;
             cyclic2.ref = cyclic1;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.strictEqual(checkDeep, true);
+            assert.isTrue(checkDeep);
         });
 
         it("returns true if referencing different but equal cyclic objects", function () {
@@ -475,7 +475,7 @@ describe("deepEqual", function () {
             cyclic2.ref = {};
             cyclic2.ref.ref = cyclic2.ref;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.strictEqual(checkDeep, true);
+            assert.isTrue(checkDeep);
         });
 
         it("returns false if referencing different and unequal cyclic objects", function () {
@@ -490,7 +490,7 @@ describe("deepEqual", function () {
             };
             cyclic2.ref.ref = cyclic2.ref;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.strictEqual(checkDeep, false);
+            assert.isFalse(checkDeep);
         });
     });
 });
@@ -498,137 +498,137 @@ describe("deepEqual", function () {
 describe("match", function () {
     it("returns true if matching regexp", function () {
         var checkMatch = samsam.match("Assertions", /[a-z]/);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if generic object and test method returning true", function () {
         var checkMatch = samsam.match("Assertions", {
             test: function () { return true; }
         });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if non matching regexp", function () {
         var checkMatch = samsam.match("Assertions 123", /^[a-z]$/);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if matching booleans", function () {
         var checkMatch = samsam.match(true, true);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if mismatching booleans", function () {
         var checkMatch = samsam.match(true, false);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if generic object with test method returning false", function () {
         var checkMatch = samsam.match("Assertions", { test: function () { return false; } });
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("should throw error if match object === null", function () {
         var checkMatch = samsam.match("Assertions 123", null);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if match object === false", function () {
         var checkMatch = samsam.match("Assertions 123", false);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if matching number against string", function () {
         var checkMatch = samsam.match("Assertions", 23);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if matching number against similar string", function () {
         var checkMatch = samsam.match("23", 23);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if matching number against itself", function () {
         var checkMatch = samsam.match(23, 23);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if matcher function returns true", function () {
         var checkMatch = samsam.match("Assertions 123", function () { return true; });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if matcher function returns false", function () {
         var checkMatch = samsam.match("Assertions 123", function () { return false; });
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if matcher function returns falsy", function () {
         var checkMatch = samsam.match("Assertions 123", function () { });
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if matcher does not return explicit true", function () {
         var checkMatch = samsam.match("Assertions 123", function () { return "Hey"; });
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if matcher is substring of matchee", function () {
         var checkMatch = samsam.match("Diskord", "or");
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if matcher is string equal to matchee", function () {
         var checkMatch = samsam.match("Diskord", "Diskord");
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if matcher is strings ignoring case", function () {
         var checkMatch = samsam.match("Look ma, case-insensitive",
             "LoOk Ma, CaSe-InSenSiTiVe");
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if match string is not substring of matchee", function () {
         var checkMatch = samsam.match("Vim", "Emacs");
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if match string is not substring of object", function () {
         var checkMatch = samsam.match({}, "Emacs");
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if matcher is not substring of object.toString", function () {
         var checkMatch = samsam.match({
             toString: function () { return "Vim"; }
         }, "Emacs");
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if null and empty string", function () {
         var checkMatch = samsam.match(null, "");
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if undefined and empty string", function () {
         var checkMatch = samsam.match(undefined, "");
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if false and empty string", function () {
         var checkMatch = samsam.match(false, "");
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if 0 and empty string", function () {
         var checkMatch = samsam.match(0, "");
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if NaN and empty string", function () {
         var checkMatch = samsam.match(NaN, "");
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if object containing all properties in matcher", function () {
@@ -645,7 +645,7 @@ describe("match", function () {
             id: 42,
             doIt: "yes"
         });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if nested matcher", function () {
@@ -670,67 +670,67 @@ describe("match", function () {
                 }
             }
         });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if empty strings", function () {
         var checkMatch = samsam.match("", "");
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if empty strings as object properties", function () {
         var checkMatch = samsam.match({ foo: "" }, { foo: "" });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if similar arrays", function () {
         var checkMatch = samsam.match([1, 2, 3], [1, 2, 3]);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if array subset", function () {
         var checkMatch = samsam.match([1, 2, 3], [2, 3]);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if single-element array subset", function () {
         var checkMatch = samsam.match([1, 2, 3], [1]);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if matching array subset", function () {
         var checkMatch = samsam.match([1, 2, 3, { id: 42 }], [{ id: 42 }]);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if mis-matching array 'subset'", function () {
         var checkMatch = samsam.match([1, 2, 3], [2, 3, 4]);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if mis-ordered array 'subset'", function () {
         var checkMatch = samsam.match([1, 2, 3], [1, 3]);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if mis-ordered, but similar arrays of objects", function () {
         var checkMatch = samsam.match([{a: "a"}, {a: "aa"}], [{a: "aa"}, {a: "a"}]);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if empty arrays", function () {
         var checkMatch = samsam.match([], []);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if objects with empty arrays", function () {
         var checkMatch = samsam.match({ xs: [] }, { xs: [] });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if nested objects with different depth", function () {
         var checkMatch = samsam.match({ a: 1 }, { b: { c: 2 } });
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if dom elements with matching data attributes", function () {
@@ -742,7 +742,7 @@ describe("match", function () {
                 return false;
             }
         }, { "data-path": "foo.bar" });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if dom elements with not matching data attributes", function () {
@@ -754,108 +754,108 @@ describe("match", function () {
                 return false;
             }
         }, { "data-path": "foo.bar" });
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if equal null properties", function () {
         var checkMatch = samsam.match({ foo: null }, { foo: null });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if unmatched null property", function () {
         var checkMatch = samsam.match({}, { foo: null });
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns false if matcher with unmatched null property", function () {
         var checkMatch = samsam.match({ foo: "arbitrary" }, { foo: null });
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if equal undefined properties", function () {
         var checkMatch = samsam.match({ foo: undefined }, { foo: undefined });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if matcher with unmatched undefined property", function () {
         var checkMatch = samsam.match({ foo: "arbitrary" }, { foo: undefined });
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if unmatched undefined property", function () {
         var checkMatch = samsam.match({}, { foo: undefined });
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if same object matches self", function () {
         var obj = { foo: undefined };
         var checkMatch = samsam.match(obj, obj);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns true if null to null", function () {
         var checkMatch = samsam.match(null, null);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if null to undefined", function () {
         var checkMatch = samsam.match(null, undefined);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if undefined to undefined", function () {
         var checkMatch = samsam.match(undefined, undefined);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if undefined to null", function () {
         var checkMatch = samsam.match(undefined, null);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     it("returns true if date objects with same date", function () {
         var date = new Date();
         var sameDate = new Date(date.getTime());
         var checkMatch = samsam.match(date, sameDate);
-        assert.strictEqual(checkMatch, true);
+        assert.isTrue(checkMatch);
     });
 
     it("returns false if date objects with different dates", function () {
         var date = new Date();
         var anotherDate = new Date(date.getTime() - 10);
         var checkMatch = samsam.match(date, anotherDate);
-        assert.strictEqual(checkMatch, false);
+        assert.isFalse(checkMatch);
     });
 
     if (typeof Set !== "undefined") {
         it("returns true if sets with same content", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([1, 2, 3]), new Set([2, 3, 1]));
-            assert.strictEqual(checkMatch, true);
+            assert.isTrue(checkMatch);
         });
 
         it("returns true if subsets", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([1, 2, 3]), new Set([3, 1]));
-            assert.strictEqual(checkMatch, true);
+            assert.isTrue(checkMatch);
         });
 
         it("returns true if subset complex types", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([1, {id: 42}, 3]), new Set([{id: 42}]));
-            assert.strictEqual(checkMatch, true);
+            assert.isTrue(checkMatch);
         });
 
         it("returns false if sets with dissimilar content", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([1, 2, 3]), new Set([2, 5, 1]));
-            assert.strictEqual(checkMatch, false);
+            assert.isFalse(checkMatch);
         });
 
         it("returns false if sets with different complex member", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([{id: 42}]), new Set([{id: 13}]));
-            assert.strictEqual(checkMatch, false);
+            assert.isFalse(checkMatch);
         });
 
         it("returns true if differently sorted complex objects", function () {
@@ -893,18 +893,18 @@ describe("match", function () {
                 start: "2015-04-03T14:00:00Z"
             }]);
             var checkMatch = samsam.match(set1, set2);
-            assert.strictEqual(checkMatch, true);
+            assert.isTrue(checkMatch);
         });
 
         it("returns false on set compared with something else", function () {
             // eslint-disable-next-line ie11/no-collection-args
-            assert.strictEqual(samsam.match(new Set([1, 2, 3]), "string"), false);
+            assert.isFalse(samsam.match(new Set([1, 2, 3]), "string"));
             // eslint-disable-next-line ie11/no-collection-args
-            assert.strictEqual(samsam.match(new Set([1, 2, 3]), false), false);
+            assert.isFalse(samsam.match(new Set([1, 2, 3]), false));
             // eslint-disable-next-line ie11/no-collection-args
-            assert.strictEqual(samsam.match(new Set([1, 2, 3]), true), false);
+            assert.isFalse(samsam.match(new Set([1, 2, 3]), true));
             // eslint-disable-next-line ie11/no-collection-args
-            assert.strictEqual(samsam.match(new Set([1, 2, 3]), 123), false);
+            assert.isFalse(samsam.match(new Set([1, 2, 3]), 123));
         });
     }
 });
@@ -912,31 +912,31 @@ describe("match", function () {
 describe("isDate", function () {
     it("returns true if valid date", function () {
         var checkDate = samsam.isDate(new Date());
-        assert.strictEqual(checkDate, true);
+        assert.isTrue(checkDate);
     });
 
     it("returns false if string", function () {
         var checkDate = samsam.isDate("String");
-        assert.strictEqual(checkDate, false);
+        assert.isFalse(checkDate);
     });
 
     it("returns false if Number", function () {
         var checkDate = samsam.isDate(123);
-        assert.strictEqual(checkDate, false);
+        assert.isFalse(checkDate);
     });
 
     it("returns false if empty string", function () {
         var checkDate = samsam.isDate("");
-        assert.strictEqual(checkDate, false);
+        assert.isFalse(checkDate);
     });
 
     it("returns false if empty object", function () {
         var checkDate = samsam.isDate({});
-        assert.strictEqual(checkDate, false);
+        assert.isFalse(checkDate);
     });
 
     it("returns false if object", function () {
         var checkDate = samsam.isDate({ id: 12 });
-        assert.strictEqual(checkDate, false);
+        assert.isFalse(checkDate);
     });
 });

--- a/lib/samsam.test.js
+++ b/lib/samsam.test.js
@@ -813,6 +813,20 @@ describe("match", function () {
         assert.strictEqual(checkMatch, false);
     });
 
+    it("returns true if date objects with same date", function () {
+        var date = new Date();
+        var sameDate = new Date(date.getTime());
+        var checkMatch = samsam.match(date, sameDate);
+        assert.strictEqual(checkMatch, true);
+    });
+
+    it("returns false if date objects with different dates", function () {
+        var date = new Date();
+        var anotherDate = new Date(date.getTime() - 10);
+        var checkMatch = samsam.match(date, anotherDate);
+        assert.strictEqual(checkMatch, false);
+    });
+
     if (typeof Set !== "undefined") {
         it("returns true if sets with same content", function () {
             // eslint-disable-next-line ie11/no-collection-args
@@ -891,20 +905,6 @@ describe("match", function () {
             assert.strictEqual(samsam.match(new Set([1, 2, 3]), true), false);
             // eslint-disable-next-line ie11/no-collection-args
             assert.strictEqual(samsam.match(new Set([1, 2, 3]), 123), false);
-        });
-
-        it("returns true if date objects with same date", function () {
-            var date = new Date();
-            var sameDate = new Date(date.getTime());
-            var checkMatch = samsam.match(date, sameDate);
-            assert.strictEqual(checkMatch, true);
-        });
-
-        it("returns false if date objects with different dates", function () {
-            var date = new Date();
-            var anotherDate = new Date(date.getTime() - 10);
-            var checkMatch = samsam.match(date, anotherDate);
-            assert.strictEqual(checkMatch, false);
         });
     }
 });

--- a/lib/samsam.test.js
+++ b/lib/samsam.test.js
@@ -1,118 +1,116 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var assert = referee.assert;
-var refute = referee.refute;
+var assert = require("assert");
 require("jsdom-global")();
 var samsam = require("./samsam");
 
 describe("isElement", function () {
-    it("should pass if DOM element node", function () {
+    it("returns true if DOM element node", function () {
         if (typeof document !== "undefined") {
             var element = document.createElement("div");
             var checkElement = samsam.isElement(element);
-            assert.equals(checkElement, true);
+            assert.strictEqual(checkElement, true);
         }
     });
 
-    it("should fail if DOM text node", function () {
+    it("returns false if DOM text node", function () {
         if (typeof document !== "undefined") {
             var element = document.createTextNode("Hello");
             var checkElement = samsam.isElement(element);
-            refute.equals(checkElement, true);
+            assert.strictEqual(checkElement, false);
         }
     });
 
-    it("should fail if node like object", function () {
+    it("returns false if node like object", function () {
         var nodeLike = { nodeType: 1 };
         var checkElement = samsam.isElement(nodeLike);
-        refute.equals(checkElement, true);
+        assert.strictEqual(checkElement, false);
     });
 
-    it("should fail if number", function () {
+    it("returns false if number", function () {
         var checkElement = samsam.isElement(42);
-        refute.equals(checkElement, true);
+        assert.strictEqual(checkElement, false);
     });
 
-    it("should fail if object", function () {
+    it("returns false if object", function () {
         var checkElement = samsam.isElement({});
-        refute.equals(checkElement, true);
+        assert.strictEqual(checkElement, false);
     });
 });
 
 describe("isArguments", function () {
-    it("should pass if arguments is an object", function () {
+    it("returns true if arguments is an object", function () {
         var checkArgs = samsam.isArguments(arguments);
-        assert.equals(checkArgs, true);
+        assert.strictEqual(checkArgs, true);
     });
 
-    it("should fail if number", function () {
+    it("returns false if number", function () {
         var checkArgs = samsam.isArguments(24);
-        refute.equals(checkArgs, true);
+        assert.strictEqual(checkArgs, false);
     });
 
-    it("should fail if empty object", function () {
+    it("returns false if empty object", function () {
         var checkArgs = samsam.isArguments({});
-        refute.equals(checkArgs, true);
+        assert.strictEqual(checkArgs, false);
     });
 
-    it("should pass if arguments object from strict-mode function", function () {
+    it("returns true if arguments object from strict-mode function", function () {
         var returnArgs = function () {
             return arguments;
         };
         var checkArgs = samsam.isArguments(returnArgs());
-        assert.equals(checkArgs, true);
+        assert.strictEqual(checkArgs, true);
     });
 });
 
 describe("isNegZero", function () {
-    it("should pass if negative zero", function () {
+    it("returns true if negative zero", function () {
         var checkZero = samsam.isNegZero(-0);
-        assert.equals(checkZero, true);
+        assert.strictEqual(checkZero, true);
     });
 
-    it("should fail if zero", function () {
+    it("returns false if zero", function () {
         var checkZero = samsam.isNegZero(0);
-        refute.equals(checkZero, true);
+        assert.strictEqual(checkZero, false);
     });
 
-    it("should fail if object", function () {
+    it("returns false if object", function () {
         var checkZero = samsam.isNegZero({});
-        refute.equals(checkZero, true);
+        assert.strictEqual(checkZero, false);
     });
 
-    it("should fail if String", function () {
+    it("returns false if String", function () {
         var checkZero = samsam.isNegZero("-0");
-        refute.equals(checkZero, true);
+        assert.strictEqual(checkZero, false);
     });
 });
 
 describe("identical", function () {
-    it("should pass if strings are identical", function () {
+    it("returns true if strings are identical", function () {
         var str = "string";
         var checkIdent = samsam.identical(str, str);
-        assert.equals(checkIdent, true);
+        assert.strictEqual(checkIdent, true);
     });
 
-    it("should pass if objects are identical", function () {
+    it("returns true if objects are identical", function () {
         var obj = { id: 42 };
         var checkIdent = samsam.identical(obj, obj);
-        assert.equals(checkIdent, true);
+        assert.strictEqual(checkIdent, true);
     });
 
-    it("should pass if NaN", function () {
+    it("returns true if NaN", function () {
         var checkIdent = samsam.identical(NaN, NaN);
-        assert.equals(checkIdent, true);
+        assert.strictEqual(checkIdent, true);
     });
 
-    it("should fail if equal but different type", function () {
+    it("returns false if equal but different type", function () {
         var checkIdent = samsam.identical(0, "0");
-        refute.equals(checkIdent, true);
+        assert.strictEqual(checkIdent, false);
     });
 
-    it("should fail on -0 and 0", function () {
+    it("returns false on -0 and 0", function () {
         var checkIdent = samsam.identical(0, -0);
-        refute.equals(checkIdent, true);
+        assert.strictEqual(checkIdent, false);
     });
 });
 
@@ -125,136 +123,136 @@ describe("deepEqual", function () {
     var sameDateWithProp = new Date(date.getTime());
     sameDateWithProp.prop = 42;
 
-    it("should pass if object to itself", function () {
+    it("returns true if object to itself", function () {
         var checkDeep = samsam.deepEqual(obj, obj);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if strings", function () {
+    it("returns true if strings", function () {
         var checkDeep = samsam.deepEqual("string", "string");
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if numbers", function () {
+    it("returns true if numbers", function () {
         var checkDeep = samsam.deepEqual(32, 32);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if boolean", function () {
+    it("returns true if boolean", function () {
         var checkDeep = samsam.deepEqual(false, false);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if null", function () {
+    it("returns true if null", function () {
         var checkDeep = samsam.deepEqual(null, null);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if undefined", function () {
+    it("returns true if undefined", function () {
         var checkDeep = samsam.deepEqual(undefined, undefined);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if function to itself", function () {
+    it("returns true if function to itself", function () {
         var checkDeep = samsam.deepEqual(func, func);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should fail if different functions", function () {
+    it("returns false if different functions", function () {
         var checkDeep = samsam.deepEqual(function () {}, function () {});
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should pass if array to itself", function () {
+    it("returns true if array to itself", function () {
         var checkDeep = samsam.deepEqual(arr, arr);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if date objects with same date", function () {
+    it("returns true if date objects with same date", function () {
         var checkDeep = samsam.deepEqual(date, sameDate);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should fail if date objects with different dates", function () {
+    it("returns false if date objects with different dates", function () {
         var checkDeep = samsam.deepEqual(date, sameDateWithProp);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if strings and numbers with coercion", function () {
+    it("returns false if strings and numbers with coercion", function () {
         var checkDeep = samsam.deepEqual("4", 4);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if numbers and strings with coercion", function () {
+    it("returns false if numbers and strings with coercion", function () {
         var checkDeep = samsam.deepEqual(4, "4");
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if number object with coercion", function () {
+    it("returns false if number object with coercion", function () {
         // eslint-disable-next-line no-new-wrappers
         var checkDeep = samsam.deepEqual(32, new Number(32));
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if number object reverse with coercion", function () {
+    it("returns false if number object reverse with coercion", function () {
         // eslint-disable-next-line no-new-wrappers
         var checkDeep = samsam.deepEqual(new Number(32), 32);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if falsy values with coercion", function () {
+    it("returns false if falsy values with coercion", function () {
         var checkDeep = samsam.deepEqual(0, "");
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if falsy values reverse with coercion", function () {
+    it("returns false if falsy values reverse with coercion", function () {
         var checkDeep = samsam.deepEqual("", 0);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if string boxing with coercion", function () {
+    it("returns false if string boxing with coercion", function () {
         // eslint-disable-next-line no-new-wrappers
         var checkDeep = samsam.deepEqual("4", new String("4"));
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if string boxing reverse with coercion", function () {
+    it("returns false if string boxing reverse with coercion", function () {
         // eslint-disable-next-line no-new-wrappers
         var checkDeep = samsam.deepEqual(new String("4"), "4");
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should pass if NaN to Nan", function () {
+    it("returns true if NaN to Nan", function () {
         var checkDeep = samsam.deepEqual(NaN, NaN);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should fail if -0 to +0", function () {
+    it("returns false if -0 to +0", function () {
         var checkDeep = samsam.deepEqual(+0, -0);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if -0 to 0", function () {
+    it("returns false if -0 to 0", function () {
         var checkDeep = samsam.deepEqual(-0, 0);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if objects with different own properties", function () {
+    it("returns false if objects with different own properties", function () {
         var checkDeep = samsam.deepEqual({ id: 42 }, { id: 42, di: 24 });
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if objects with different own properties values", function () {
+    it("returns false if objects with different own properties values", function () {
         var checkDeep = samsam.deepEqual({ id: 42 }, { id: undefined });
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if objects with one property with different values", function () {
+    it("returns false if objects with one property with different values", function () {
         var checkDeep = samsam.deepEqual({ id: 42 }, { id: 24 });
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should pass if complex objects", function () {
+    it("returns true if complex objects", function () {
         var deepObject = {
             id: 42,
             name: "Hey",
@@ -272,161 +270,171 @@ describe("deepEqual", function () {
             id: 42,
             name: "Hey"
         });
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if arrays", function () {
+    it("returns true if arrays", function () {
         var checkDeep = samsam.deepEqual(
             [1, 2, "Hey there", func, { id: 42, prop: [2, 3] }],
             [1, 2, "Hey there", func, { id: 42, prop: [2, 3] }]
         );
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should fail if nested array with shallow array", function () {
+    it("returns false if nested array with shallow array", function () {
         var checkDeep = samsam.deepEqual([["hey"]], ["hey"]);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if arrays with different custom properties", function () {
+    it("returns false if arrays with different custom properties", function () {
         var arr1 = [1, 2, 3];
         var arr2 = [1, 2, 3];
         arr1.prop = 42;
         var checkDeep = samsam.deepEqual(arr1, arr2);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should pass if regexp literals", function () {
+    it("returns true if regexp literals", function () {
         var checkDeep = samsam.deepEqual(/a/, /a/);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if regexp objects", function () {
+    it("returns true if regexp objects", function () {
         var checkDeep = samsam.deepEqual(new RegExp("[a-z]+"), new RegExp("[a-z]+"));
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should fail if regexp objects with custom properties", function () {
+    it("returns false if regexp objects with custom properties", function () {
         var re1 = new RegExp("[a-z]+");
         var re2 = new RegExp("[a-z]+");
         re2.id = 42;
         var checkDeep = samsam.deepEqual(re1, re2);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if different objects", function () {
+    it("returns false if different objects", function () {
         var checkDeep = samsam.deepEqual({id: 42}, {});
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if object to null", function () {
+    it("returns false if object to null", function () {
         var checkDeep = samsam.deepEqual({}, null);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if object to undefined", function () {
+    it("returns false if object to undefined", function () {
         var checkDeep = samsam.deepEqual({}, undefined);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if object to false", function () {
+    it("returns false if object to false", function () {
         var checkDeep = samsam.deepEqual({}, false);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if false to object", function () {
+    it("returns false if false to object", function () {
         var checkDeep = samsam.deepEqual(false, {});
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if object to true", function () {
+    it("returns false if object to true", function () {
         var checkDeep = samsam.deepEqual({}, true);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if true to object", function () {
+    it("returns false if true to object", function () {
         var checkDeep = samsam.deepEqual(true, {});
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if 'empty' object to date", function () {
+    it("returns false if 'empty' object to date", function () {
         var checkDeep = samsam.deepEqual({}, new Date());
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if 'empty' object to string object", function () {
+    it("returns false if 'empty' object to string object", function () {
         var checkDeep = samsam.deepEqual({}, String());
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if 'empty' object to number object", function () {
+    it("returns false if 'empty' object to number object", function () {
         var checkDeep = samsam.deepEqual({}, Number());
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should fail if 'empty' object to empty array", function () {
+    it("returns false if 'empty' object to empty array", function () {
         var checkDeep = samsam.deepEqual({}, []);
-        refute.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, false);
     });
 
-    it("should pass if arguments to array", function () {
+    it("returns true if arguments to array", function () {
         var gather = function () { return arguments; };
         var checkDeep = samsam.deepEqual([1, 2, {}, []], gather(1, 2, {}, []));
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if array to arguments", function () {
+    it("returns true if array to arguments", function () {
         var gather = function () { return arguments; };
         var checkDeep = samsam.deepEqual(gather(), []);
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
-    it("should pass if arguments to array like object", function () {
+    it("returns true if arguments to array like object", function () {
         var gather = function () { return arguments; };
         var arrayLike = { length: 4, "0": 1, "1": 2, "2": {}, "3": [] };
         var checkDeep = samsam.deepEqual(arrayLike, gather(1, 2, {}, []));
-        assert.equals(checkDeep, true);
+        assert.strictEqual(checkDeep, true);
     });
 
     if (typeof Set !== "undefined") {
-        it("should pass sets with the same content", function () {
+        it("returns true if set with the same content", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkDeep = samsam.deepEqual(new Set([1, 2, 3]), new Set([2, 1, 3]));
-            assert.equals(checkDeep, true);
+            assert.strictEqual(checkDeep, true);
         });
 
-        it("should fail sets with the different content", function () {
+        it("returns false if set with the different content", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkDeep = samsam.deepEqual(new Set([1, 2, 3]), new Set([2, 5, 3]));
-            refute.equals(checkDeep, true);
+            assert.strictEqual(checkDeep, false);
+        });
+
+        it("returns false on set compared with something else", function () {
+            // eslint-disable-next-line ie11/no-collection-args
+            assert.strictEqual(samsam.deepEqual(new Set([1, 2, 3]), "string"), false);
+            // eslint-disable-next-line ie11/no-collection-args
+            assert.strictEqual(samsam.deepEqual(new Set([1, 2, 3]), false), false);
+            // eslint-disable-next-line ie11/no-collection-args
+            assert.strictEqual(samsam.deepEqual(new Set([1, 2, 3]), true), false);
+            // eslint-disable-next-line ie11/no-collection-args
+            assert.strictEqual(samsam.deepEqual(new Set([1, 2, 3]), 123), false);
         });
     }
-
 
     /**
     * Tests for cyclic objects.
     */
     describe("deepEqual (cyclic objects)", function () {
-        it("should pass if equal cyclic objects (cycle on 2nd level)", function () {
+        it("returns true if equal cyclic objects (cycle on 2nd level)", function () {
             var cyclic1 = {};
             var cyclic2 = {};
             cyclic1.ref = cyclic1;
             cyclic2.ref = cyclic2;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.equals(checkDeep, true);
+            assert.strictEqual(checkDeep, true);
         });
 
-        it("should fail if different cyclic objects (cycle on 2nd level)", function () {
+        it("returns false if different cyclic objects (cycle on 2nd level)", function () {
             var cyclic1 = {};
             var cyclic2 = {};
             cyclic1.ref = cyclic1;
             cyclic2.ref = cyclic2;
             cyclic2.ref2 = cyclic2;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            refute.equals(checkDeep, true);
+            assert.strictEqual(checkDeep, false);
         });
 
-        it("should pass if equal cyclic objects (cycle on 3rd level)", function () {
+        it("returns true if equal cyclic objects (cycle on 3rd level)", function () {
             var cyclic1 = {};
             var cyclic2 = {};
             cyclic1.ref = {};
@@ -434,10 +442,10 @@ describe("deepEqual", function () {
             cyclic2.ref = {};
             cyclic2.ref.ref = cyclic2;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.equals(checkDeep, true);
+            assert.strictEqual(checkDeep, true);
         });
 
-        it("should fail if different cyclic objects (cycle on 3rd level)", function () {
+        it("returns false if different cyclic objects (cycle on 3rd level)", function () {
             var cyclic1 = {};
             var cyclic2 = {};
             cyclic1.ref = {};
@@ -446,19 +454,19 @@ describe("deepEqual", function () {
             cyclic2.ref.ref = cyclic2;
             cyclic2.ref.ref2 = cyclic2;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            refute.equals(checkDeep, true);
+            assert.strictEqual(checkDeep, false);
         });
 
-        it("should pass if equal objects even though only one object is cyclic", function () {
+        it("returns true if equal objects even though only one object is cyclic", function () {
             var cyclic1 = {};
             var cyclic2 = {};
             cyclic1.ref = cyclic1;
             cyclic2.ref = cyclic1;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.equals(checkDeep, true);
+            assert.strictEqual(checkDeep, true);
         });
 
-        it("should pass if referencing different but equal cyclic objects", function () {
+        it("returns true if referencing different but equal cyclic objects", function () {
             var cyclic1 = {};
             var cyclic2 = {};
             cyclic1.ref = {
@@ -467,10 +475,10 @@ describe("deepEqual", function () {
             cyclic2.ref = {};
             cyclic2.ref.ref = cyclic2.ref;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            assert.equals(checkDeep, true);
+            assert.strictEqual(checkDeep, true);
         });
 
-        it("should fail if referencing different and unequal cyclic objects", function () {
+        it("returns false if referencing different and unequal cyclic objects", function () {
             var cyclic1 = {a: "a"};
             var cyclic2 = {a: "a"};
             cyclic1.ref = {
@@ -482,148 +490,148 @@ describe("deepEqual", function () {
             };
             cyclic2.ref.ref = cyclic2.ref;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
-            refute.equals(checkDeep, true);
+            assert.strictEqual(checkDeep, false);
         });
     });
 });
 
 describe("match", function () {
-    it("should pass if matching regexp", function () {
+    it("returns true if matching regexp", function () {
         var checkMatch = samsam.match("Assertions", /[a-z]/);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if generic object and test method returning true", function () {
+    it("returns true if generic object and test method returning true", function () {
         var checkMatch = samsam.match("Assertions", {
             test: function () { return true; }
         });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if non matching regexp", function () {
+    it("returns false if non matching regexp", function () {
         var checkMatch = samsam.match("Assertions 123", /^[a-z]$/);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if matching booleans", function () {
+    it("returns true if matching booleans", function () {
         var checkMatch = samsam.match(true, true);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if mismatching booleans", function () {
+    it("returns false if mismatching booleans", function () {
         var checkMatch = samsam.match(true, false);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if generic object with test method returning false", function () {
+    it("returns false if generic object with test method returning false", function () {
         var checkMatch = samsam.match("Assertions", { test: function () { return false; } });
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
     it("should throw error if match object === null", function () {
         var checkMatch = samsam.match("Assertions 123", null);
-        refute.equals(checkMatch, Error);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if match object === false", function () {
+    it("returns false if match object === false", function () {
         var checkMatch = samsam.match("Assertions 123", false);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if matching number against string", function () {
+    it("returns false if matching number against string", function () {
         var checkMatch = samsam.match("Assertions", 23);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if matching number against similar string", function () {
+    it("returns false if matching number against similar string", function () {
         var checkMatch = samsam.match("23", 23);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if matching number against itself", function () {
+    it("returns true if matching number against itself", function () {
         var checkMatch = samsam.match(23, 23);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if matcher function returns true", function () {
+    it("returns true if matcher function returns true", function () {
         var checkMatch = samsam.match("Assertions 123", function () { return true; });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if matcher function returns false", function () {
+    it("returns false if matcher function returns false", function () {
         var checkMatch = samsam.match("Assertions 123", function () { return false; });
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if matcher function returns falsy", function () {
+    it("returns false if matcher function returns falsy", function () {
         var checkMatch = samsam.match("Assertions 123", function () { });
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if matcher does not return explicit true", function () {
+    it("returns false if matcher does not return explicit true", function () {
         var checkMatch = samsam.match("Assertions 123", function () { return "Hey"; });
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if matcher is substring of matchee", function () {
+    it("returns true if matcher is substring of matchee", function () {
         var checkMatch = samsam.match("Diskord", "or");
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if matcher is string equal to matchee", function () {
+    it("returns true if matcher is string equal to matchee", function () {
         var checkMatch = samsam.match("Diskord", "Diskord");
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if matcher is strings ignoring case", function () {
+    it("returns true if matcher is strings ignoring case", function () {
         var checkMatch = samsam.match("Look ma, case-insensitive",
             "LoOk Ma, CaSe-InSenSiTiVe");
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if match string is not substring of matchee", function () {
+    it("returns false if match string is not substring of matchee", function () {
         var checkMatch = samsam.match("Vim", "Emacs");
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if match string is not substring of object", function () {
+    it("returns false if match string is not substring of object", function () {
         var checkMatch = samsam.match({}, "Emacs");
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if matcher is not substring of object.toString", function () {
+    it("returns false if matcher is not substring of object.toString", function () {
         var checkMatch = samsam.match({
             toString: function () { return "Vim"; }
         }, "Emacs");
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if null and empty string", function () {
+    it("returns false if null and empty string", function () {
         var checkMatch = samsam.match(null, "");
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if undefined and empty string", function () {
+    it("returns false if undefined and empty string", function () {
         var checkMatch = samsam.match(undefined, "");
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if false and empty string", function () {
+    it("returns false if false and empty string", function () {
         var checkMatch = samsam.match(false, "");
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if 0 and empty string", function () {
+    it("returns false if 0 and empty string", function () {
         var checkMatch = samsam.match(0, "");
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if NaN and empty string", function () {
+    it("returns false if NaN and empty string", function () {
         var checkMatch = samsam.match(NaN, "");
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if object containing all properties in matcher", function () {
+    it("returns true if object containing all properties in matcher", function () {
         var object = {
             id: 42,
             name: "Christian",
@@ -637,10 +645,10 @@ describe("match", function () {
             id: 42,
             doIt: "yes"
         });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if nested matcher", function () {
+    it("returns true if nested matcher", function () {
         var object = {
             id: 42,
             name: "Christian",
@@ -662,70 +670,70 @@ describe("match", function () {
                 }
             }
         });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if empty strings", function () {
+    it("returns true if empty strings", function () {
         var checkMatch = samsam.match("", "");
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if empty strings as object properties", function () {
+    it("returns true if empty strings as object properties", function () {
         var checkMatch = samsam.match({ foo: "" }, { foo: "" });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if similar arrays", function () {
+    it("returns true if similar arrays", function () {
         var checkMatch = samsam.match([1, 2, 3], [1, 2, 3]);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if array subset", function () {
+    it("returns true if array subset", function () {
         var checkMatch = samsam.match([1, 2, 3], [2, 3]);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if single-element array subset", function () {
+    it("returns true if single-element array subset", function () {
         var checkMatch = samsam.match([1, 2, 3], [1]);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if matching array subset", function () {
+    it("returns true if matching array subset", function () {
         var checkMatch = samsam.match([1, 2, 3, { id: 42 }], [{ id: 42 }]);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if mis-matching array 'subset'", function () {
+    it("returns false if mis-matching array 'subset'", function () {
         var checkMatch = samsam.match([1, 2, 3], [2, 3, 4]);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if mis-ordered array 'subset'", function () {
+    it("returns false if mis-ordered array 'subset'", function () {
         var checkMatch = samsam.match([1, 2, 3], [1, 3]);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if mis-ordered, but similar arrays of objects", function () {
+    it("returns false if mis-ordered, but similar arrays of objects", function () {
         var checkMatch = samsam.match([{a: "a"}, {a: "aa"}], [{a: "aa"}, {a: "a"}]);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if empty arrays", function () {
+    it("returns true if empty arrays", function () {
         var checkMatch = samsam.match([], []);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if objects with empty arrays", function () {
+    it("returns true if objects with empty arrays", function () {
         var checkMatch = samsam.match({ xs: [] }, { xs: [] });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if nested objects with different depth", function () {
+    it("returns false if nested objects with different depth", function () {
         var checkMatch = samsam.match({ a: 1 }, { b: { c: 2 } });
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if dom elements with matching data attributes", function () {
+    it("returns true if dom elements with matching data attributes", function () {
         var checkMatch = samsam.match({
             getAttribute: function (name) {
                 if (name === "data-path") {
@@ -734,10 +742,10 @@ describe("match", function () {
                 return false;
             }
         }, { "data-path": "foo.bar" });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if dom elements with not matching data attributes", function () {
+    it("returns false if dom elements with not matching data attributes", function () {
         var checkMatch = samsam.match({
             getAttribute: function (name) {
                 if (name === "data-path") {
@@ -746,97 +754,97 @@ describe("match", function () {
                 return false;
             }
         }, { "data-path": "foo.bar" });
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if equal null properties", function () {
+    it("returns true if equal null properties", function () {
         var checkMatch = samsam.match({ foo: null }, { foo: null });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if unmatched null property", function () {
+    it("returns false if unmatched null property", function () {
         var checkMatch = samsam.match({}, { foo: null });
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should fail if matcher with unmatched null property", function () {
+    it("returns false if matcher with unmatched null property", function () {
         var checkMatch = samsam.match({ foo: "arbitrary" }, { foo: null });
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if equal undefined properties", function () {
+    it("returns true if equal undefined properties", function () {
         var checkMatch = samsam.match({ foo: undefined }, { foo: undefined });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if matcher with unmatched undefined property", function () {
+    it("returns false if matcher with unmatched undefined property", function () {
         var checkMatch = samsam.match({ foo: "arbitrary" }, { foo: undefined });
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if unmatched undefined property", function () {
+    it("returns true if unmatched undefined property", function () {
         var checkMatch = samsam.match({}, { foo: undefined });
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if same object matches self", function () {
+    it("returns true if same object matches self", function () {
         var obj = { foo: undefined };
         var checkMatch = samsam.match(obj, obj);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should pass if null to null", function () {
+    it("returns true if null to null", function () {
         var checkMatch = samsam.match(null, null);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if null to undefined", function () {
+    it("returns false if null to undefined", function () {
         var checkMatch = samsam.match(null, undefined);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
-    it("should pass if undefined to undefined", function () {
+    it("returns true if undefined to undefined", function () {
         var checkMatch = samsam.match(undefined, undefined);
-        assert.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, true);
     });
 
-    it("should fail if undefined to null", function () {
+    it("returns false if undefined to null", function () {
         var checkMatch = samsam.match(undefined, null);
-        refute.equals(checkMatch, true);
+        assert.strictEqual(checkMatch, false);
     });
 
     if (typeof Set !== "undefined") {
-        it("should pass if sets with same content", function () {
+        it("returns true if sets with same content", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([1, 2, 3]), new Set([2, 3, 1]));
-            assert.equals(checkMatch, true);
+            assert.strictEqual(checkMatch, true);
         });
 
-        it("should pass if subsets", function () {
+        it("returns true if subsets", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([1, 2, 3]), new Set([3, 1]));
-            assert.equals(checkMatch, true);
+            assert.strictEqual(checkMatch, true);
         });
 
-        it("should pass if subset complex types", function () {
+        it("returns true if subset complex types", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([1, {id: 42}, 3]), new Set([{id: 42}]));
-            assert.equals(checkMatch, true);
+            assert.strictEqual(checkMatch, true);
         });
 
-        it("should fail if sets with dissimilar content", function () {
+        it("returns false if sets with dissimilar content", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([1, 2, 3]), new Set([2, 5, 1]));
-            refute.equals(checkMatch, true);
+            assert.strictEqual(checkMatch, false);
         });
 
-        it("should fail if sets with different complex member", function () {
+        it("returns false if sets with different complex member", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var checkMatch = samsam.match(new Set([{id: 42}]), new Set([{id: 13}]));
-            refute.equals(checkMatch, true);
+            assert.strictEqual(checkMatch, false);
         });
 
-        it("should pass if differently sorted complex objects", function () {
+        it("returns true if differently sorted complex objects", function () {
             // eslint-disable-next-line ie11/no-collection-args
             var set1 = new Set([{
                 end: "2019-08-07T18:00:00Z",
@@ -871,53 +879,64 @@ describe("match", function () {
                 start: "2015-04-03T14:00:00Z"
             }]);
             var checkMatch = samsam.match(set1, set2);
-            assert.equals(checkMatch, true);
+            assert.strictEqual(checkMatch, true);
         });
 
-        it("should pass if date objects with same date", function () {
+        it("returns false on set compared with something else", function () {
+            // eslint-disable-next-line ie11/no-collection-args
+            assert.strictEqual(samsam.match(new Set([1, 2, 3]), "string"), false);
+            // eslint-disable-next-line ie11/no-collection-args
+            assert.strictEqual(samsam.match(new Set([1, 2, 3]), false), false);
+            // eslint-disable-next-line ie11/no-collection-args
+            assert.strictEqual(samsam.match(new Set([1, 2, 3]), true), false);
+            // eslint-disable-next-line ie11/no-collection-args
+            assert.strictEqual(samsam.match(new Set([1, 2, 3]), 123), false);
+        });
+
+        it("returns true if date objects with same date", function () {
             var date = new Date();
             var sameDate = new Date(date.getTime());
             var checkMatch = samsam.match(date, sameDate);
-            assert.equals(checkMatch, true);
+            assert.strictEqual(checkMatch, true);
         });
 
-        it("should fail if date objects with different dates", function () {
+        it("returns false if date objects with different dates", function () {
             var date = new Date();
             var anotherDate = new Date(date.getTime() - 10);
             var checkMatch = samsam.match(date, anotherDate);
-            refute.equals(checkMatch, true);
+            assert.strictEqual(checkMatch, false);
         });
     }
 });
 
 describe("isDate", function () {
-    it("should pass if valid date", function () {
+    it("returns true if valid date", function () {
         var checkDate = samsam.isDate(new Date());
-        assert.equals(checkDate, true);
+        assert.strictEqual(checkDate, true);
     });
 
-    it("should fail if string", function () {
+    it("returns false if string", function () {
         var checkDate = samsam.isDate("String");
-        refute.equals(checkDate, true);
+        assert.strictEqual(checkDate, false);
     });
 
-    it("should fail if Number", function () {
+    it("returns false if Number", function () {
         var checkDate = samsam.isDate(123);
-        refute.equals(checkDate, true);
+        assert.strictEqual(checkDate, false);
     });
 
-    it("should fail if empty string", function () {
+    it("returns false if empty string", function () {
         var checkDate = samsam.isDate("");
-        refute.equals(checkDate, true);
+        assert.strictEqual(checkDate, false);
     });
 
-    it("should fail if empty object", function () {
+    it("returns false if empty object", function () {
         var checkDate = samsam.isDate({});
-        refute.equals(checkDate, true);
+        assert.strictEqual(checkDate, false);
     });
 
-    it("should fail if object", function () {
+    it("returns false if object", function () {
         var checkDate = samsam.isDate({ id: 12 });
-        refute.equals(checkDate, true);
+        assert.strictEqual(checkDate, false);
     });
 });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
+    "@sinonjs/referee": "^2.0.0",
     "eslint": "^4.16.0",
     "eslint-config-sinon": "^1.0.3",
     "eslint-plugin-ie11": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@sinonjs/referee": "^2.0.0",
     "eslint": "^4.16.0",
     "eslint-config-sinon": "^1.0.3",
     "eslint-plugin-ie11": "^1.0.0",


### PR DESCRIPTION
RE #25

In an attempt to clean `deepEqual` and `match` methods it was deemed better to ensure that they always return `true`/`false`.

I've:
- added test cases for these changes
- updated the other tests to use `asset.deepEqual` as making the changes didn't make any tests fail due to the weak type checking of `referee.assert` and `referee.refute`
- updated the tests name to be more explicit as to what the behaviour of `samsam` returns.