### PR TITLE
Add coveralls badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # samsam
 
 [![Build status](https://secure.travis-ci.org/sinonjs/samsam.svg?branch=master)](http://travis-ci.org/sinonjs/samsam)
+[![Coverage Status](https://coveralls.io/repos/github/sinonjs/samsam/badge.svg?branch=master)](https://coveralls.io/github/sinonjs/samsam?branch=master)
 
 Value identification and comparison functions
 


### PR DESCRIPTION
I've activated coveralls for this repository. This PR adds the badge to `README.md`

#### How to verify - mandatory
1. Observe that there's a coveralls report at the end of the pull request
2. Once merged, verify that the badge in `README.md` displays a coverage value
