### PR TITLE
Remove isDate method from being exported

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,13 +31,6 @@ Underscore.js/lodash, this function will return `false` if `object` is an
 holds the value `1`.
 
 
-### `isDate(object)`
-
-Returns true if the object is a `Date`, or *date-like*. Duck typing of date
-objects work by checking that the object has a `getTime` function whose return
-value equals the return value from the object's `valueOf`.
-
-
 ## Comparison functions
 
 

--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -18,6 +18,10 @@ function getClass(value) {
     return o.toString.call(value).split(/[ \]]/)[1];
 }
 
+function isDate(value) {
+    return value instanceof Date;
+}
+
 /**
  * @name samsam.isArguments
  * @param Object object
@@ -59,20 +63,6 @@ function isElement(object) {
         return false;
     }
     return true;
-}
-
-/**
- * @name samsam.isDate
- * @param Object value
- *
- * Returns true if the object is a ``Date``, or *date-like*. Duck typing
- * of date objects work by checking that the object has a ``getTime``
- * function whose return value equals the return value from the object's
- * ``valueOf``.
- */
-function isDate(value) {
-    return typeof value.getTime === "function" &&
-        value.getTime() === value.valueOf();
 }
 
 /**
@@ -420,7 +410,6 @@ function match(object, matcher) {
 module.exports = {
     isArguments: isArguments,
     isElement: isElement,
-    isDate: isDate,
     isNegZero: isNegZero,
     identical: identical,
     deepEqual: deepEqualCyclic,

--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -206,7 +206,9 @@ function deepEqualCyclic(first, second) {
         }
 
         // Elements are only equal if identical(expected, actual)
-        if (isElement(obj1) || isElement(obj2)) { return false; }
+        if (isElement(obj1) || isElement(obj2)) {
+            return false;
+        }
 
         var isDate1 = isDate(obj1);
         var isDate2 = isDate(obj2);
@@ -217,7 +219,9 @@ function deepEqualCyclic(first, second) {
         }
 
         if (obj1 instanceof RegExp && obj2 instanceof RegExp) {
-            if (obj1.toString() !== obj2.toString()) { return false; }
+            if (obj1.toString() !== obj2.toString()) {
+                return false;
+            }
         }
 
         var class1 = getClass(obj1);
@@ -320,8 +324,12 @@ function arrayContains(array, subset, compare) {
     for (i = 0, l = array.length; i < l; ++i) {
         if (compare(array[i], subset[0])) {
             for (j = 0, k = subset.length; j < k; ++j) {
-                if ((i + j) >= l) { return false; }
-                if (!compare(array[i + j], subset[j])) { return false; }
+                if ((i + j) >= l) {
+                    return false;
+                }
+                if (!compare(array[i + j], subset[j])) {
+                    return false;
+                }
             }
             return true;
         }
@@ -360,8 +368,8 @@ function match(object, matcher) {
         return matcher === object;
     }
 
-    if (typeof (matcher) === "undefined") {
-        return typeof (object) === "undefined";
+    if (typeof matcher === "undefined") {
+        return typeof object === "undefined";
     }
 
     if (matcher === null) {

--- a/lib/samsam.test.js
+++ b/lib/samsam.test.js
@@ -908,35 +908,3 @@ describe("match", function () {
         });
     }
 });
-
-describe("isDate", function () {
-    it("returns true if valid date", function () {
-        var checkDate = samsam.isDate(new Date());
-        assert.isTrue(checkDate);
-    });
-
-    it("returns false if string", function () {
-        var checkDate = samsam.isDate("String");
-        assert.isFalse(checkDate);
-    });
-
-    it("returns false if Number", function () {
-        var checkDate = samsam.isDate(123);
-        assert.isFalse(checkDate);
-    });
-
-    it("returns false if empty string", function () {
-        var checkDate = samsam.isDate("");
-        assert.isFalse(checkDate);
-    });
-
-    it("returns false if empty object", function () {
-        var checkDate = samsam.isDate({});
-        assert.isFalse(checkDate);
-    });
-
-    it("returns false if object", function () {
-        var checkDate = samsam.isDate({ id: 12 });
-        assert.isFalse(checkDate);
-    });
-});


### PR DESCRIPTION
This removes `isDate` from being exposed and updates the internal method to check if `value instanceof Date`. It resolves #30.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
