### PR TITLE
Import match from sinon

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -7,7 +7,9 @@ env:
   node: true
 
 globals:
+  Map: false
   Set: false
+  Symbol: false
 
 plugins:
   - ie11
@@ -21,21 +23,23 @@ rules:
   ie11/no-weak-collections: error
 
 overrides:
-    files: '*.test.*'
-    plugins:
-        - mocha
-    env:
-        mocha: true
-    rules:
-        mocha/handle-done-callback: error
-        mocha/no-exclusive-tests: error
-        mocha/no-global-tests: error
-        mocha/no-hooks-for-single-case: off
-        mocha/no-identical-title: error
-        mocha/no-mocha-arrows: error
-        mocha/no-nested-tests: error
-        mocha/no-return-and-callback: error
-        mocha/no-sibling-hooks: error
-        mocha/no-skipped-tests: error
-        mocha/no-top-level-hooks: error
-
+  files: '*.test.*'
+  plugins:
+    - mocha
+  env:
+    mocha: true
+  rules:
+    max-nested-callbacks:
+      - warn
+      - 6
+    mocha/handle-done-callback: error
+    mocha/no-exclusive-tests: error
+    mocha/no-global-tests: error
+    mocha/no-hooks-for-single-case: off
+    mocha/no-identical-title: error
+    mocha/no-mocha-arrows: error
+    mocha/no-nested-tests: error
+    mocha/no-return-and-callback: error
+    mocha/no-sibling-hooks: error
+    mocha/no-skipped-tests: error
+    mocha/no-top-level-hooks: error

--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -32,7 +32,7 @@ var keys = Object.keys;
  *
  * Supports cyclic objects.
  */
-function deepEqualCyclic(first, second) {
+function deepEqualCyclic(first, second, match) {
     // used for cyclic comparison
     // contain already visited objects
     var objects1 = [];
@@ -48,6 +48,16 @@ function deepEqualCyclic(first, second) {
 
     // does the recursion for the deep equal check
     return (function deepEqual(obj1, obj2, path1, path2) {
+        // If both are matchers they must be the same instance in order to be
+        // considered equal If we didn't do that we would end up running one
+        // matcher against the other
+        if (match && match.isMatcher(obj1)) {
+            if (match.isMatcher(obj2)) {
+                return obj1 === obj2;
+            }
+            return obj1.test(obj2);
+        }
+
         var type1 = typeof obj1;
         var type2 = typeof obj2;
 
@@ -185,17 +195,8 @@ function deepEqualCyclic(first, second) {
 }
 
 deepEqualCyclic.use = function(match) {
-    return function deepEqual$matcher(a, b) {
-        // If both are matchers they must be the same instance in order to be considered equal
-        // If we didn't do that we would end up running one matcher against the other
-        if (match.isMatcher(a)) {
-            if (match.isMatcher(b)) {
-                return a === b;
-            }
-            return a.test(b);
-        }
-
-        return deepEqualCyclic(a, b, deepEqual$matcher);
+    return function(a, b) {
+        return deepEqualCyclic(a, b, match);
     };
 };
 

--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -184,4 +184,19 @@ function deepEqualCyclic(first, second) {
     })(first, second, "$1", "$2");
 }
 
+deepEqualCyclic.use = function(match) {
+    return function deepEqual$matcher(a, b) {
+        // If both are matchers they must be the same instance in order to be considered equal
+        // If we didn't do that we would end up running one matcher against the other
+        if (match.isMatcher(a)) {
+            if (match.isMatcher(b)) {
+                return a === b;
+            }
+            return a.test(b);
+        }
+
+        return deepEqualCyclic(a, b, deepEqual$matcher);
+    };
+};
+
 module.exports = deepEqualCyclic;

--- a/lib/iterable-to-string.js
+++ b/lib/iterable-to-string.js
@@ -1,0 +1,39 @@
+"use strict";
+
+var slice = require("@sinonjs/commons").prototypes.string.slice;
+var typeOf = require("@sinonjs/commons").typeOf;
+
+module.exports = function iterableToString(obj) {
+    var representation = "";
+
+    function stringify(item) {
+        return typeof item === "string" ? "'" + item + "'" : String(item);
+    }
+
+    function mapToString(map) {
+        /* eslint-disable-next-line local-rules/no-prototype-methods */
+        map.forEach(function(value, key) {
+            representation +=
+                "[" + stringify(key) + "," + stringify(value) + "],";
+        });
+
+        representation = slice(representation, 0, -1);
+        return representation;
+    }
+
+    function genericIterableToString(iterable) {
+        /* eslint-disable-next-line local-rules/no-prototype-methods */
+        iterable.forEach(function(value) {
+            representation += stringify(value) + ",";
+        });
+
+        representation = slice(representation, 0, -1);
+        return representation;
+    }
+
+    if (typeOf(obj) === "map") {
+        return mapToString(obj);
+    }
+
+    return genericIterableToString(obj);
+};

--- a/lib/iterable-to-string.test.js
+++ b/lib/iterable-to-string.test.js
@@ -1,0 +1,47 @@
+"use strict";
+
+var assert = require("@sinonjs/referee").assert;
+var iterableToString = require("./iterable-to-string");
+
+describe("iterableToString", function() {
+    it("returns an String representation of Array objects", function() {
+        var arr = [1, "one", true, undefined, null];
+        var expected = "1,'one',true,undefined,null";
+
+        assert.equals(iterableToString(arr), expected);
+    });
+
+    if (typeof Map === "function") {
+        it("returns an String representation of Map objects", function() {
+            var map = new Map();
+            map.set(1, 1);
+            map.set("one", "one");
+            map.set(true, true);
+            map.set(undefined, undefined);
+            map.set(null, null);
+            var expected =
+                "[1,1]," +
+                "['one','one']," +
+                "[true,true]," +
+                "[undefined,undefined]," +
+                "[null,null]";
+
+            assert.equals(iterableToString(map), expected);
+        });
+    }
+
+    if (typeof Set === "function") {
+        it("returns an String representation of Set objects", function() {
+            var set = new Set();
+            set.add(1);
+            set.add("one");
+            set.add(true);
+            set.add(undefined);
+            set.add(null);
+
+            var expected = "1,'one',true,undefined,null";
+
+            assert.equals(iterableToString(set), expected);
+        });
+    }
+});

--- a/lib/sinon-match.js
+++ b/lib/sinon-match.js
@@ -1,0 +1,456 @@
+"use strict";
+
+var arrayProto = require("@sinonjs/commons").prototypes.array;
+var deepEqual = require("./deep-equal").use(match); // eslint-disable-line no-use-before-define
+var every = require("@sinonjs/commons").every;
+var functionName = require("@sinonjs/commons").functionName;
+var get = require("lodash.get");
+var iterableToString = require("./iterable-to-string");
+var objectProto = require("@sinonjs/commons").prototypes.object;
+var stringProto = require("@sinonjs/commons").prototypes.string;
+var typeOf = require("@sinonjs/commons").typeOf;
+var valueToString = require("@sinonjs/commons").valueToString;
+
+var arrayIndexOf = arrayProto.indexOf;
+var arrayEvery = arrayProto.every;
+var join = arrayProto.join;
+var map = arrayProto.map;
+var some = arrayProto.some;
+
+var hasOwnProperty = objectProto.hasOwnProperty;
+var isPrototypeOf = objectProto.isPrototypeOf;
+
+var stringIndexOf = stringProto.indexOf;
+
+function assertType(value, type, name) {
+    var actual = typeOf(value);
+    if (actual !== type) {
+        throw new TypeError(
+            "Expected type of " +
+                name +
+                " to be " +
+                type +
+                ", but was " +
+                actual
+        );
+    }
+}
+
+function assertMethodExists(value, method, name, methodPath) {
+    if (value[method] == null) {
+        throw new TypeError(
+            "Expected " + name + " to have method " + methodPath
+        );
+    }
+}
+
+var matcher = {
+    toString: function() {
+        return this.message;
+    }
+};
+
+function isMatcher(object) {
+    return isPrototypeOf(matcher, object);
+}
+
+function matchObject(expectation, actual) {
+    if (actual === null || actual === undefined) {
+        return false;
+    }
+
+    return arrayEvery(Object.keys(expectation), function(key) {
+        var exp = expectation[key];
+        var act = actual[key];
+
+        if (isMatcher(exp)) {
+            if (!exp.test(act)) {
+                return false;
+            }
+        } else if (typeOf(exp) === "object") {
+            if (!matchObject(exp, act)) {
+                return false;
+            }
+        } else if (!deepEqual(exp, act)) {
+            return false;
+        }
+
+        return true;
+    });
+}
+
+var TYPE_MAP = {
+    function: function(m, expectation, message) {
+        m.test = expectation;
+        m.message = message || "match(" + functionName(expectation) + ")";
+    },
+    number: function(m, expectation) {
+        m.test = function(actual) {
+            // we need type coercion here
+            return expectation == actual; // eslint-disable-line eqeqeq
+        };
+    },
+    object: function(m, expectation) {
+        var array = [];
+
+        if (typeof expectation.test === "function") {
+            m.test = function(actual) {
+                return expectation.test(actual) === true;
+            };
+            m.message = "match(" + functionName(expectation.test) + ")";
+            return m;
+        }
+
+        array = map(Object.keys(expectation), function(key) {
+            return key + ": " + valueToString(expectation[key]);
+        });
+
+        m.test = function(actual) {
+            return matchObject(expectation, actual);
+        };
+        m.message = "match(" + join(array, ", ") + ")";
+
+        return m;
+    },
+    regexp: function(m, expectation) {
+        m.test = function(actual) {
+            return typeof actual === "string" && expectation.test(actual);
+        };
+    },
+    string: function(m, expectation) {
+        m.test = function(actual) {
+            return (
+                typeof actual === "string" &&
+                stringIndexOf(actual, expectation) !== -1
+            );
+        };
+        m.message = 'match("' + expectation + '")';
+    }
+};
+
+function match(expectation, message) {
+    var m = Object.create(matcher);
+    var type = typeOf(expectation);
+
+    if (type in TYPE_MAP) {
+        TYPE_MAP[type](m, expectation, message);
+    } else {
+        m.test = function(actual) {
+            return deepEqual(expectation, actual);
+        };
+    }
+
+    if (!m.message) {
+        m.message = "match(" + valueToString(expectation) + ")";
+    }
+
+    return m;
+}
+
+matcher.or = function(m2) {
+    if (!arguments.length) {
+        throw new TypeError("Matcher expected");
+    } else if (!isMatcher(m2)) {
+        m2 = match(m2);
+    }
+    var m1 = this;
+    var or = Object.create(matcher);
+    or.test = function(actual) {
+        return m1.test(actual) || m2.test(actual);
+    };
+    or.message = m1.message + ".or(" + m2.message + ")";
+    return or;
+};
+
+matcher.and = function(m2) {
+    if (!arguments.length) {
+        throw new TypeError("Matcher expected");
+    } else if (!isMatcher(m2)) {
+        m2 = match(m2);
+    }
+    var m1 = this;
+    var and = Object.create(matcher);
+    and.test = function(actual) {
+        return m1.test(actual) && m2.test(actual);
+    };
+    and.message = m1.message + ".and(" + m2.message + ")";
+    return and;
+};
+
+match.isMatcher = isMatcher;
+
+match.any = match(function() {
+    return true;
+}, "any");
+
+match.defined = match(function(actual) {
+    return actual !== null && actual !== undefined;
+}, "defined");
+
+match.truthy = match(function(actual) {
+    return !!actual;
+}, "truthy");
+
+match.falsy = match(function(actual) {
+    return !actual;
+}, "falsy");
+
+match.same = function(expectation) {
+    return match(function(actual) {
+        return expectation === actual;
+    }, "same(" + valueToString(expectation) + ")");
+};
+
+match.in = function(arrayOfExpectations) {
+    if (!Array.isArray(arrayOfExpectations)) {
+        throw new TypeError("array expected");
+    }
+
+    return match(function(actual) {
+        return some(arrayOfExpectations, function(expectation) {
+            return expectation === actual;
+        });
+    }, "in(" + valueToString(arrayOfExpectations) + ")");
+};
+
+match.typeOf = function(type) {
+    assertType(type, "string", "type");
+    return match(function(actual) {
+        return typeOf(actual) === type;
+    }, 'typeOf("' + type + '")');
+};
+
+match.instanceOf = function(type) {
+    if (
+        typeof Symbol === "undefined" ||
+        typeof Symbol.hasInstance === "undefined"
+    ) {
+        assertType(type, "function", "type");
+    } else {
+        assertMethodExists(
+            type,
+            Symbol.hasInstance,
+            "type",
+            "[Symbol.hasInstance]"
+        );
+    }
+    return match(function(actual) {
+        return actual instanceof type;
+    }, "instanceOf(" +
+        (functionName(type) || Object.prototype.toString.call(type)) +
+        ")");
+};
+
+function createPropertyMatcher(propertyTest, messagePrefix) {
+    return function(property, value) {
+        assertType(property, "string", "property");
+        var onlyProperty = arguments.length === 1;
+        var message = messagePrefix + '("' + property + '"';
+        if (!onlyProperty) {
+            message += ", " + valueToString(value);
+        }
+        message += ")";
+        return match(function(actual) {
+            if (
+                actual === undefined ||
+                actual === null ||
+                !propertyTest(actual, property)
+            ) {
+                return false;
+            }
+            return onlyProperty || deepEqual(value, actual[property]);
+        }, message);
+    };
+}
+
+match.has = createPropertyMatcher(function(actual, property) {
+    if (typeof actual === "object") {
+        return property in actual;
+    }
+    return actual[property] !== undefined;
+}, "has");
+
+match.hasOwn = createPropertyMatcher(function(actual, property) {
+    return hasOwnProperty(actual, property);
+}, "hasOwn");
+
+match.hasNested = function(property, value) {
+    assertType(property, "string", "property");
+    var onlyProperty = arguments.length === 1;
+    var message = 'hasNested("' + property + '"';
+    if (!onlyProperty) {
+        message += ", " + valueToString(value);
+    }
+    message += ")";
+    return match(function(actual) {
+        if (
+            actual === undefined ||
+            actual === null ||
+            get(actual, property) === undefined
+        ) {
+            return false;
+        }
+        return onlyProperty || deepEqual(value, get(actual, property));
+    }, message);
+};
+
+match.every = function(predicate) {
+    if (!isMatcher(predicate)) {
+        throw new TypeError("Matcher expected");
+    }
+
+    return match(function(actual) {
+        if (typeOf(actual) === "object") {
+            return every(Object.keys(actual), function(key) {
+                return predicate.test(actual[key]);
+            });
+        }
+
+        return (
+            !!actual &&
+            typeOf(actual.forEach) === "function" &&
+            every(actual, function(element) {
+                return predicate.test(element);
+            })
+        );
+    }, "every(" + predicate.message + ")");
+};
+
+match.some = function(predicate) {
+    if (!isMatcher(predicate)) {
+        throw new TypeError("Matcher expected");
+    }
+
+    return match(function(actual) {
+        if (typeOf(actual) === "object") {
+            return !every(Object.keys(actual), function(key) {
+                return !predicate.test(actual[key]);
+            });
+        }
+
+        return (
+            !!actual &&
+            typeOf(actual.forEach) === "function" &&
+            !every(actual, function(element) {
+                return !predicate.test(element);
+            })
+        );
+    }, "some(" + predicate.message + ")");
+};
+
+match.array = match.typeOf("array");
+
+match.array.deepEquals = function(expectation) {
+    return match(function(actual) {
+        // Comparing lengths is the fastest way to spot a difference before iterating through every item
+        var sameLength = actual.length === expectation.length;
+        return (
+            typeOf(actual) === "array" &&
+            sameLength &&
+            every(actual, function(element, index) {
+                return expectation[index] === element;
+            })
+        );
+    }, "deepEquals([" + iterableToString(expectation) + "])");
+};
+
+match.array.startsWith = function(expectation) {
+    return match(function(actual) {
+        return (
+            typeOf(actual) === "array" &&
+            every(expectation, function(expectedElement, index) {
+                return actual[index] === expectedElement;
+            })
+        );
+    }, "startsWith([" + iterableToString(expectation) + "])");
+};
+
+match.array.endsWith = function(expectation) {
+    return match(function(actual) {
+        // This indicates the index in which we should start matching
+        var offset = actual.length - expectation.length;
+
+        return (
+            typeOf(actual) === "array" &&
+            every(expectation, function(expectedElement, index) {
+                return actual[offset + index] === expectedElement;
+            })
+        );
+    }, "endsWith([" + iterableToString(expectation) + "])");
+};
+
+match.array.contains = function(expectation) {
+    return match(function(actual) {
+        return (
+            typeOf(actual) === "array" &&
+            every(expectation, function(expectedElement) {
+                return arrayIndexOf(actual, expectedElement) !== -1;
+            })
+        );
+    }, "contains([" + iterableToString(expectation) + "])");
+};
+
+match.map = match.typeOf("map");
+
+match.map.deepEquals = function mapDeepEquals(expectation) {
+    return match(function(actual) {
+        // Comparing lengths is the fastest way to spot a difference before iterating through every item
+        var sameLength = actual.size === expectation.size;
+        return (
+            typeOf(actual) === "map" &&
+            sameLength &&
+            every(actual, function(element, key) {
+                return expectation.has(key) && expectation.get(key) === element;
+            })
+        );
+    }, "deepEquals(Map[" + iterableToString(expectation) + "])");
+};
+
+match.map.contains = function mapContains(expectation) {
+    return match(function(actual) {
+        return (
+            typeOf(actual) === "map" &&
+            every(expectation, function(element, key) {
+                return actual.has(key) && actual.get(key) === element;
+            })
+        );
+    }, "contains(Map[" + iterableToString(expectation) + "])");
+};
+
+match.set = match.typeOf("set");
+
+match.set.deepEquals = function setDeepEquals(expectation) {
+    return match(function(actual) {
+        // Comparing lengths is the fastest way to spot a difference before iterating through every item
+        var sameLength = actual.size === expectation.size;
+        return (
+            typeOf(actual) === "set" &&
+            sameLength &&
+            every(actual, function(element) {
+                return expectation.has(element);
+            })
+        );
+    }, "deepEquals(Set[" + iterableToString(expectation) + "])");
+};
+
+match.set.contains = function setContains(expectation) {
+    return match(function(actual) {
+        return (
+            typeOf(actual) === "set" &&
+            every(expectation, function(element) {
+                return actual.has(element);
+            })
+        );
+    }, "contains(Set[" + iterableToString(expectation) + "])");
+};
+
+match.bool = match.typeOf("boolean");
+match.number = match.typeOf("number");
+match.string = match.typeOf("string");
+match.object = match.typeOf("object");
+match.func = match.typeOf("function");
+match.regexp = match.typeOf("regexp");
+match.date = match.typeOf("date");
+match.symbol = match.typeOf("symbol");
+
+module.exports = match;

--- a/lib/sinon-match.test.js
+++ b/lib/sinon-match.test.js
@@ -1,0 +1,1430 @@
+"use strict";
+
+var assert = require("@sinonjs/referee").assert;
+var refute = require("@sinonjs/referee").refute;
+var sinonMatch = require("./sinon-match");
+
+function propertyMatcherTests(matcher, additionalTests) {
+    return function() {
+        it("returns matcher", function() {
+            var has = matcher("foo");
+
+            assert(sinonMatch.isMatcher(has));
+        });
+
+        it("throws if first argument is not string", function() {
+            assert.exception(
+                function() {
+                    matcher();
+                },
+                { name: "TypeError" }
+            );
+            assert.exception(
+                function() {
+                    matcher(123);
+                },
+                { name: "TypeError" }
+            );
+        });
+
+        it("returns false if value is undefined or null", function() {
+            var has = matcher("foo");
+
+            assert.isFalse(has.test(undefined));
+            assert.isFalse(has.test(null));
+        });
+
+        it("returns true if object has property", function() {
+            var has = matcher("foo");
+
+            assert(has.test({ foo: null }));
+        });
+
+        it("returns false if object value is not equal to given value", function() {
+            var has = matcher("foo", 1);
+
+            assert.isFalse(has.test({ foo: null }));
+        });
+
+        it("returns true if object value is equal to given value", function() {
+            var has = matcher("message", "sinon rocks");
+
+            assert(has.test({ message: "sinon rocks" }));
+            assert(has.test(new Error("sinon rocks")));
+        });
+
+        it("returns true if string property matches", function() {
+            var has = matcher("length", 5);
+
+            assert(has.test("sinon"));
+        });
+
+        it("allows to expect undefined", function() {
+            var has = matcher("foo", undefined);
+
+            assert.isFalse(has.test({ foo: 1 }));
+        });
+
+        it("compares value deeply", function() {
+            var has = matcher("foo", { bar: "doo", test: 42 });
+
+            assert(has.test({ foo: { bar: "doo", test: 42 } }));
+        });
+
+        it("compares with matcher", function() {
+            var has = matcher("callback", sinonMatch.typeOf("function"));
+
+            assert(has.test({ callback: function() {} }));
+        });
+
+        if (typeof additionalTests === "function") {
+            additionalTests();
+        }
+    };
+}
+
+describe("sinonMatch", function() {
+    it("returns matcher", function() {
+        var match = sinonMatch(function() {});
+
+        assert(sinonMatch.isMatcher(match));
+    });
+
+    it("exposes test function", function() {
+        var test = function() {};
+
+        var match = sinonMatch(test);
+
+        assert.same(match.test, test);
+    });
+
+    it("returns true if properties are equal", function() {
+        var match = sinonMatch({ str: "sinon", nr: 1 });
+
+        assert(match.test({ str: "sinon", nr: 1, other: "ignored" }));
+    });
+
+    it("returns true if properties are deep equal", function() {
+        var match = sinonMatch({ deep: { str: "sinon" } });
+
+        assert(match.test({ deep: { str: "sinon", ignored: "value" } }));
+    });
+
+    it("returns false if a property is not equal", function() {
+        var match = sinonMatch({ str: "sinon", nr: 1 });
+
+        assert.isFalse(match.test({ str: "sinon", nr: 2 }));
+    });
+
+    it("returns false if a property is missing", function() {
+        var match = sinonMatch({ str: "sinon", nr: 1 });
+
+        assert.isFalse(match.test({ nr: 1 }));
+    });
+
+    it("returns true if array is equal", function() {
+        var match = sinonMatch({ arr: ["a", "b"] });
+
+        assert(match.test({ arr: ["a", "b"] }));
+    });
+
+    it("returns false if array is not equal", function() {
+        var match = sinonMatch({ arr: ["b", "a"] });
+
+        assert.isFalse(match.test({ arr: ["a", "b"] }));
+    });
+
+    it("returns false if array is not equal (even if the contents would match (deep equal))", function() {
+        var match = sinonMatch([{ str: "sinon" }]);
+
+        assert.isFalse(match.test([{ str: "sinon", ignored: "value" }]));
+    });
+
+    it("returns true if number objects are equal", function() {
+        /*eslint-disable no-new-wrappers*/
+        var match = sinonMatch({ one: new Number(1) });
+
+        assert(match.test({ one: new Number(1) }));
+        /*eslint-enable no-new-wrappers*/
+    });
+
+    it("returns true if test matches", function() {
+        var match = sinonMatch({ prop: sinonMatch.typeOf("boolean") });
+
+        assert(match.test({ prop: true }));
+    });
+
+    it("returns false if test does not match", function() {
+        var match = sinonMatch({ prop: sinonMatch.typeOf("boolean") });
+
+        assert.isFalse(match.test({ prop: "no" }));
+    });
+
+    it("returns true if deep test matches", function() {
+        var match = sinonMatch({
+            deep: { prop: sinonMatch.typeOf("boolean") }
+        });
+
+        assert(match.test({ deep: { prop: true } }));
+    });
+
+    it("returns false if deep test does not match", function() {
+        var match = sinonMatch({
+            deep: { prop: sinonMatch.typeOf("boolean") }
+        });
+
+        assert.isFalse(match.test({ deep: { prop: "no" } }));
+    });
+
+    it("returns false if tested value is null or undefined", function() {
+        var match = sinonMatch({});
+
+        assert.isFalse(match.test(null));
+        assert.isFalse(match.test(undefined));
+    });
+
+    it("returns true if error message matches", function() {
+        var match = sinonMatch({ message: "evil error" });
+
+        assert(match.test(new Error("evil error")));
+    });
+
+    it("returns true if string property matches", function() {
+        var match = sinonMatch({ length: 5 });
+
+        assert(match.test("sinon"));
+    });
+
+    it("returns true if number property matches", function() {
+        var match = sinonMatch({ toFixed: sinonMatch.func });
+
+        assert(match.test(0));
+    });
+
+    it("returns true for string match", function() {
+        var match = sinonMatch("sinon");
+
+        assert(match.test("sinon"));
+    });
+
+    it("returns true for substring match", function() {
+        var match = sinonMatch("no");
+
+        assert(match.test("sinon"));
+    });
+
+    it("returns false for string mismatch", function() {
+        var match = sinonMatch("Sinon.JS");
+
+        assert.isFalse(match.test(null));
+        assert.isFalse(match.test({}));
+        assert.isFalse(match.test("sinon"));
+        assert.isFalse(match.test("sinon.js"));
+    });
+
+    it("returns true for regexp match", function() {
+        var match = sinonMatch(/^[sino]+$/);
+
+        assert(match.test("sinon"));
+    });
+
+    it("returns false for regexp string mismatch", function() {
+        var match = sinonMatch(/^[sin]+$/);
+
+        assert.isFalse(match.test("sinon"));
+    });
+
+    it("returns false for regexp type mismatch", function() {
+        var match = sinonMatch(/.*/);
+
+        assert.isFalse(match.test());
+        assert.isFalse(match.test(null));
+        assert.isFalse(match.test(123));
+        assert.isFalse(match.test({}));
+    });
+
+    it("returns true for number match", function() {
+        var match = sinonMatch(1);
+
+        assert(match.test(1));
+        assert(match.test("1"));
+        assert(match.test(true));
+    });
+
+    it("returns false for number mismatch", function() {
+        var match = sinonMatch(1);
+
+        assert.isFalse(match.test());
+        assert.isFalse(match.test(null));
+        assert.isFalse(match.test(2));
+        assert.isFalse(match.test(false));
+        assert.isFalse(match.test({}));
+    });
+
+    it("returns true for Symbol match", function() {
+        if (typeof Symbol === "function") {
+            var symbol = Symbol();
+
+            var match = sinonMatch(symbol);
+
+            assert(match.test(symbol));
+        }
+    });
+
+    it("returns false for Symbol mismatch", function() {
+        if (typeof Symbol === "function") {
+            var match = sinonMatch(Symbol());
+
+            assert.isFalse(match.test());
+            assert.isFalse(match.test(Symbol(null)));
+            assert.isFalse(match.test(Symbol()));
+            assert.isFalse(match.test(Symbol({})));
+        }
+    });
+
+    it("returns true for Symbol inside object", function() {
+        if (typeof Symbol === "function") {
+            var symbol = Symbol();
+
+            var match = sinonMatch({ prop: symbol });
+
+            assert(match.test({ prop: symbol }));
+        }
+    });
+
+    it("returns true if test function in object returns true", function() {
+        var match = sinonMatch({
+            test: function() {
+                return true;
+            }
+        });
+
+        assert(match.test());
+    });
+
+    it("returns false if test function in object returns false", function() {
+        var match = sinonMatch({
+            test: function() {
+                return false;
+            }
+        });
+
+        assert.isFalse(match.test());
+    });
+
+    it("returns false if test function in object returns nothing", function() {
+        var match = sinonMatch({ test: function() {} });
+
+        assert.isFalse(match.test());
+    });
+
+    it("passes actual value to test function in object", function() {
+        var match = sinonMatch({
+            test: function(arg) {
+                return arg;
+            }
+        });
+
+        assert(match.test(true));
+    });
+
+    it("uses matcher", function() {
+        var match = sinonMatch(sinonMatch("test"));
+
+        assert(match.test("testing"));
+    });
+
+    describe(".toString", function() {
+        it("returns message", function() {
+            var message = "hello sinonMatch";
+
+            var match = sinonMatch(function() {}, message);
+
+            assert.same(match.toString(), message);
+        });
+
+        it("defaults to match(functionName)", function() {
+            var match = sinonMatch(function custom() {});
+
+            assert.same(match.toString(), "match(custom)");
+        });
+    });
+
+    describe(".any", function() {
+        it("is matcher", function() {
+            assert(sinonMatch.isMatcher(sinonMatch.any));
+        });
+
+        it("returns true when tested", function() {
+            assert(sinonMatch.any.test());
+        });
+    });
+
+    describe(".defined", function() {
+        it("is matcher", function() {
+            assert(sinonMatch.isMatcher(sinonMatch.defined));
+        });
+
+        it("returns false if test is called with null", function() {
+            assert.isFalse(sinonMatch.defined.test(null));
+        });
+
+        it("returns false if test is called with undefined", function() {
+            assert.isFalse(sinonMatch.defined.test(undefined));
+        });
+
+        it("returns true if test is called with any value", function() {
+            assert(sinonMatch.defined.test(false));
+            assert(sinonMatch.defined.test(true));
+            assert(sinonMatch.defined.test(0));
+            assert(sinonMatch.defined.test(1));
+            assert(sinonMatch.defined.test(""));
+        });
+
+        it("returns true if test is called with any object", function() {
+            assert(sinonMatch.defined.test({}));
+            assert(sinonMatch.defined.test(function() {}));
+        });
+    });
+
+    describe(".truthy", function() {
+        it("is matcher", function() {
+            assert(sinonMatch.isMatcher(sinonMatch.truthy));
+        });
+
+        it("returns true if test is called with trueish value", function() {
+            assert(sinonMatch.truthy.test(true));
+            assert(sinonMatch.truthy.test(1));
+            assert(sinonMatch.truthy.test("yes"));
+        });
+
+        it("returns false if test is called falsy value", function() {
+            assert.isFalse(sinonMatch.truthy.test(false));
+            assert.isFalse(sinonMatch.truthy.test(null));
+            assert.isFalse(sinonMatch.truthy.test(undefined));
+            assert.isFalse(sinonMatch.truthy.test(""));
+        });
+    });
+
+    describe(".falsy", function() {
+        it("is matcher", function() {
+            assert(sinonMatch.isMatcher(sinonMatch.falsy));
+        });
+
+        it("returns true if test is called falsy value", function() {
+            assert(sinonMatch.falsy.test(false));
+            assert(sinonMatch.falsy.test(null));
+            assert(sinonMatch.falsy.test(undefined));
+            assert(sinonMatch.falsy.test(""));
+        });
+
+        it("returns false if test is called with trueish value", function() {
+            assert.isFalse(sinonMatch.falsy.test(true));
+            assert.isFalse(sinonMatch.falsy.test(1));
+            assert.isFalse(sinonMatch.falsy.test("yes"));
+        });
+    });
+
+    describe(".same", function() {
+        it("returns matcher", function() {
+            var same = sinonMatch.same();
+
+            assert(sinonMatch.isMatcher(same));
+        });
+
+        it("returns true if test is called with same argument", function() {
+            var object = {};
+            var same = sinonMatch.same(object);
+
+            assert(same.test(object));
+        });
+
+        it("returns true if test is called with same symbol", function() {
+            if (typeof Symbol === "function") {
+                var symbol = Symbol();
+                var same = sinonMatch.same(symbol);
+
+                assert(same.test(symbol));
+            }
+        });
+
+        it("returns false if test is not called with same argument", function() {
+            var same = sinonMatch.same({});
+
+            assert.isFalse(same.test({}));
+        });
+    });
+
+    describe(".in", function() {
+        it("returns matcher", function() {
+            var inMatcher = sinonMatch.in([]);
+            assert(sinonMatch.isMatcher(inMatcher));
+        });
+
+        it("throws if given argument is not an array", function() {
+            var arg = "not-array";
+
+            assert.exception(
+                function() {
+                    sinonMatch.in(arg);
+                },
+                { name: "TypeError", message: "array expected" }
+            );
+        });
+
+        describe("when given argument is an array", function() {
+            var arrays = [
+                [1, 2, 3],
+                ["a", "b", "c"],
+                [{ a: "a" }, { b: "b" }],
+                [function() {}, function() {}],
+                [null, undefined]
+            ];
+
+            it("returns true if the tested value in the given array", function() {
+                arrays.forEach(function(array) {
+                    var inMatcher = sinonMatch.in(array);
+                    assert.isTrue(inMatcher.test(array[0]));
+                });
+            });
+
+            it("returns false if the tested value not in the given array", function() {
+                arrays.forEach(function(array) {
+                    var inMatcher = sinonMatch.in(array);
+                    assert.isFalse(inMatcher.test("something else"));
+                });
+            });
+        });
+    });
+
+    describe(".typeOf", function() {
+        it("throws if given argument is not a string", function() {
+            assert.exception(
+                function() {
+                    sinonMatch.typeOf();
+                },
+                { name: "TypeError" }
+            );
+            assert.exception(
+                function() {
+                    sinonMatch.typeOf(123);
+                },
+                { name: "TypeError" }
+            );
+        });
+
+        it("returns matcher", function() {
+            var typeOf = sinonMatch.typeOf("string");
+
+            assert(sinonMatch.isMatcher(typeOf));
+        });
+
+        it("returns true if test is called with string", function() {
+            var typeOf = sinonMatch.typeOf("string");
+
+            assert(typeOf.test("Sinon.JS"));
+        });
+
+        it("returns false if test is not called with string", function() {
+            var typeOf = sinonMatch.typeOf("string");
+
+            assert.isFalse(typeOf.test(123));
+        });
+
+        it("returns true if test is called with symbol", function() {
+            if (typeof Symbol === "function") {
+                var typeOf = sinonMatch.typeOf("symbol");
+
+                assert(typeOf.test(Symbol()));
+            }
+        });
+
+        it("returns true if test is called with regexp", function() {
+            var typeOf = sinonMatch.typeOf("regexp");
+
+            assert(typeOf.test(/.+/));
+        });
+
+        it("returns false if test is not called with regexp", function() {
+            var typeOf = sinonMatch.typeOf("regexp");
+
+            assert.isFalse(typeOf.test(true));
+        });
+    });
+
+    describe(".instanceOf", function() {
+        it("throws if given argument is not a function", function() {
+            assert.exception(
+                function() {
+                    sinonMatch.instanceOf();
+                },
+                { name: "TypeError" }
+            );
+            assert.exception(
+                function() {
+                    sinonMatch.instanceOf("foo");
+                },
+                { name: "TypeError" }
+            );
+        });
+
+        if (
+            typeof Symbol !== "undefined" &&
+            typeof Symbol.hasInstance !== "undefined"
+        ) {
+            it("does not throw if given argument defines Symbol.hasInstance", function() {
+                var objectWithCustomTypeChecks = {};
+                objectWithCustomTypeChecks[Symbol.hasInstance] = function() {};
+                sinonMatch.instanceOf(objectWithCustomTypeChecks);
+            });
+        }
+
+        it("returns matcher", function() {
+            var instanceOf = sinonMatch.instanceOf(function() {});
+
+            assert(sinonMatch.isMatcher(instanceOf));
+        });
+
+        it("returns true if test is called with instance of argument", function() {
+            var instanceOf = sinonMatch.instanceOf(Array);
+
+            assert(instanceOf.test([]));
+        });
+
+        it("returns false if test is not called with instance of argument", function() {
+            var instanceOf = sinonMatch.instanceOf(Array);
+
+            assert.isFalse(instanceOf.test({}));
+        });
+    });
+
+    describe(".has", propertyMatcherTests(sinonMatch.has));
+    describe(".hasOwn", propertyMatcherTests(sinonMatch.hasOwn));
+
+    describe(
+        ".hasNested",
+        propertyMatcherTests(sinonMatch.hasNested, function() {
+            it("compares nested value", function() {
+                var hasNested = sinonMatch.hasNested("foo.bar", "doo");
+
+                assert(hasNested.test({ foo: { bar: "doo" } }));
+            });
+
+            it("compares nested array value", function() {
+                var hasNested = sinonMatch.hasNested("foo[0].bar", "doo");
+
+                assert(hasNested.test({ foo: [{ bar: "doo" }] }));
+            });
+        })
+    );
+
+    describe(".hasSpecial", function() {
+        it("returns true if object has inherited property", function() {
+            var has = sinonMatch.has("toString");
+
+            assert(has.test({}));
+        });
+
+        it("only includes property in message", function() {
+            var has = sinonMatch.has("test");
+
+            assert.equals(has.toString(), 'has("test")');
+        });
+
+        it("includes property and value in message", function() {
+            var has = sinonMatch.has("test", undefined);
+
+            assert.equals(has.toString(), 'has("test", undefined)');
+        });
+
+        it("returns true if string function matches", function() {
+            var has = sinonMatch.has("toUpperCase", sinonMatch.func);
+
+            assert(has.test("sinon"));
+        });
+
+        it("returns true if number function matches", function() {
+            var has = sinonMatch.has("toFixed", sinonMatch.func);
+
+            assert(has.test(0));
+        });
+
+        it("returns true if object has Symbol", function() {
+            if (typeof Symbol === "function") {
+                var symbol = Symbol();
+
+                var has = sinonMatch.has("prop", symbol);
+
+                assert(has.test({ prop: symbol }));
+            }
+        });
+
+        it("returns true if embedded object has Symbol", function() {
+            if (typeof Symbol === "function") {
+                var symbol = Symbol();
+
+                var has = sinonMatch.has(
+                    "prop",
+                    sinonMatch.has("embedded", symbol)
+                );
+
+                assert(has.test({ prop: { embedded: symbol }, ignored: 42 }));
+            }
+        });
+    });
+
+    describe(".hasOwnSpecial", function() {
+        it("returns false if object has inherited property", function() {
+            var hasOwn = sinonMatch.hasOwn("toString");
+
+            assert.isFalse(hasOwn.test({}));
+        });
+
+        it("only includes property in message", function() {
+            var hasOwn = sinonMatch.hasOwn("test");
+
+            assert.equals(hasOwn.toString(), 'hasOwn("test")');
+        });
+
+        it("includes property and value in message", function() {
+            var hasOwn = sinonMatch.hasOwn("test", undefined);
+
+            assert.equals(hasOwn.toString(), 'hasOwn("test", undefined)');
+        });
+    });
+
+    describe(".every", function() {
+        it("throws if given argument is not a matcher", function() {
+            assert.exception(
+                function() {
+                    sinonMatch.every({});
+                },
+                { name: "TypeError" }
+            );
+            assert.exception(
+                function() {
+                    sinonMatch.every(123);
+                },
+                { name: "TypeError" }
+            );
+            assert.exception(
+                function() {
+                    sinonMatch.every("123");
+                },
+                { name: "TypeError" }
+            );
+        });
+
+        it("returns matcher", function() {
+            var every = sinonMatch.every(sinonMatch.any);
+
+            assert(sinonMatch.isMatcher(every));
+        });
+
+        it('wraps the given matcher message with an "every()"', function() {
+            var every = sinonMatch.every(sinonMatch.number);
+
+            assert.equals(every.toString(), 'every(typeOf("number"))');
+        });
+
+        it("fails to match anything that is not an object or an iterable", function() {
+            var every = sinonMatch.every(sinonMatch.any);
+
+            refute(every.test(1));
+            refute(every.test("a"));
+            refute(every.test(null));
+            refute(every.test(function() {}));
+        });
+
+        it("matches an object if the predicate is true for every property", function() {
+            var every = sinonMatch.every(sinonMatch.number);
+
+            assert(every.test({ a: 1, b: 2 }));
+        });
+
+        it("fails if the predicate is false for some of the object properties", function() {
+            var every = sinonMatch.every(sinonMatch.number);
+
+            refute(every.test({ a: 1, b: "b" }));
+        });
+
+        it("matches an array if the predicate is true for every element", function() {
+            var every = sinonMatch.every(sinonMatch.number);
+
+            assert(every.test([1, 2]));
+        });
+
+        it("fails if the predicate is false for some of the array elements", function() {
+            var every = sinonMatch.every(sinonMatch.number);
+
+            refute(every.test([1, "b"]));
+        });
+
+        if (typeof Set === "function") {
+            it("matches an iterable if the predicate is true for every element", function() {
+                var every = sinonMatch.every(sinonMatch.number);
+                var set = new Set();
+                set.add(1);
+                set.add(2);
+
+                assert(every.test(set));
+            });
+
+            it("fails if the predicate is false for some of the iterable elements", function() {
+                var every = sinonMatch.every(sinonMatch.number);
+                var set = new Set();
+                set.add(1);
+                set.add("b");
+
+                refute(every.test(set));
+            });
+        }
+    });
+
+    describe(".some", function() {
+        it("throws if given argument is not a matcher", function() {
+            assert.exception(
+                function() {
+                    sinonMatch.some({});
+                },
+                { name: "TypeError" }
+            );
+            assert.exception(
+                function() {
+                    sinonMatch.some(123);
+                },
+                { name: "TypeError" }
+            );
+            assert.exception(
+                function() {
+                    sinonMatch.some("123");
+                },
+                { name: "TypeError" }
+            );
+        });
+
+        it("returns matcher", function() {
+            var some = sinonMatch.some(sinonMatch.any);
+
+            assert(sinonMatch.isMatcher(some));
+        });
+
+        it('wraps the given matcher message with an "some()"', function() {
+            var some = sinonMatch.some(sinonMatch.number);
+
+            assert.equals(some.toString(), 'some(typeOf("number"))');
+        });
+
+        it("fails to match anything that is not an object or an iterable", function() {
+            var some = sinonMatch.some(sinonMatch.any);
+
+            refute(some.test(1));
+            refute(some.test("a"));
+            refute(some.test(null));
+            refute(some.test(function() {}));
+        });
+
+        it("matches an object if the predicate is true for some of the properties", function() {
+            var some = sinonMatch.some(sinonMatch.number);
+
+            assert(some.test({ a: 1, b: "b" }));
+        });
+
+        it("fails if the predicate is false for all of the object properties", function() {
+            var some = sinonMatch.some(sinonMatch.number);
+
+            refute(some.test({ a: "a", b: "b" }));
+        });
+
+        it("matches an array if the predicate is true for some element", function() {
+            var some = sinonMatch.some(sinonMatch.number);
+
+            assert(some.test([1, "b"]));
+        });
+
+        it("fails if the predicate is false for all of the array elements", function() {
+            var some = sinonMatch.some(sinonMatch.number);
+
+            refute(some.test(["a", "b"]));
+        });
+
+        if (typeof Set === "function") {
+            it("matches an iterable if the predicate is true for some element", function() {
+                var some = sinonMatch.some(sinonMatch.number);
+                var set = new Set();
+                set.add(1);
+                set.add("b");
+
+                assert(some.test(set));
+            });
+
+            it("fails if the predicate is false for all of the iterable elements", function() {
+                var some = sinonMatch.some(sinonMatch.number);
+                var set = new Set();
+                set.add("a");
+                set.add("b");
+
+                refute(some.test(set));
+            });
+        }
+    });
+
+    describe(".bool", function() {
+        it("is typeOf boolean matcher", function() {
+            var bool = sinonMatch.bool;
+
+            assert(sinonMatch.isMatcher(bool));
+            assert.equals(bool.toString(), 'typeOf("boolean")');
+        });
+    });
+
+    describe(".number", function() {
+        it("is typeOf number matcher", function() {
+            var number = sinonMatch.number;
+
+            assert(sinonMatch.isMatcher(number));
+            assert.equals(number.toString(), 'typeOf("number")');
+        });
+    });
+
+    describe(".string", function() {
+        it("is typeOf string matcher", function() {
+            var string = sinonMatch.string;
+
+            assert(sinonMatch.isMatcher(string));
+            assert.equals(string.toString(), 'typeOf("string")');
+        });
+    });
+
+    describe(".object", function() {
+        it("is typeOf object matcher", function() {
+            var object = sinonMatch.object;
+
+            assert(sinonMatch.isMatcher(object));
+            assert.equals(object.toString(), 'typeOf("object")');
+        });
+    });
+
+    describe(".func", function() {
+        it("is typeOf function matcher", function() {
+            var func = sinonMatch.func;
+
+            assert(sinonMatch.isMatcher(func));
+            assert.equals(func.toString(), 'typeOf("function")');
+        });
+    });
+
+    describe(".array", function() {
+        it("is typeOf array matcher", function() {
+            var array = sinonMatch.array;
+
+            assert(sinonMatch.isMatcher(array));
+            assert.equals(array.toString(), 'typeOf("array")');
+        });
+
+        describe("array.deepEquals", function() {
+            it("has a .deepEquals matcher", function() {
+                var deepEquals = sinonMatch.array.deepEquals([1, 2, 3]);
+
+                assert(sinonMatch.isMatcher(deepEquals));
+                assert.equals(deepEquals.toString(), "deepEquals([1,2,3])");
+            });
+
+            it("matches arrays with the exact same elements", function() {
+                var deepEquals = sinonMatch.array.deepEquals([1, 2, 3]);
+                assert(deepEquals.test([1, 2, 3]));
+                assert.isFalse(deepEquals.test([1, 2]));
+                assert.isFalse(deepEquals.test([3]));
+            });
+
+            it("fails when passed a non-array object", function() {
+                var deepEquals = sinonMatch.array.deepEquals([
+                    "one",
+                    "two",
+                    "three"
+                ]);
+                assert.isFalse(
+                    deepEquals.test({
+                        0: "one",
+                        1: "two",
+                        2: "three",
+                        length: 3
+                    })
+                );
+            });
+        });
+
+        describe("array.startsWith", function() {
+            it("has a .startsWith matcher", function() {
+                var startsWith = sinonMatch.array.startsWith([1, 2]);
+
+                assert(sinonMatch.isMatcher(startsWith));
+                assert.equals(startsWith.toString(), "startsWith([1,2])");
+            });
+
+            it("matches arrays starting with the same elements", function() {
+                assert(sinonMatch.array.startsWith([1]).test([1, 2]));
+                assert(sinonMatch.array.startsWith([1, 2]).test([1, 2]));
+                assert.isFalse(
+                    sinonMatch.array.startsWith([1, 2, 3]).test([1, 2])
+                );
+                assert.isFalse(sinonMatch.array.startsWith([2]).test([1, 2]));
+            });
+
+            it("fails when passed a non-array object", function() {
+                var startsWith = sinonMatch.array.startsWith(["one", "two"]);
+                assert.isFalse(
+                    startsWith.test({
+                        0: "one",
+                        1: "two",
+                        2: "three",
+                        length: 3
+                    })
+                );
+            });
+        });
+
+        describe("array.endsWith", function() {
+            it("has an .endsWith matcher", function() {
+                var endsWith = sinonMatch.array.endsWith([2, 3]);
+
+                assert(sinonMatch.isMatcher(endsWith));
+                assert.equals(endsWith.toString(), "endsWith([2,3])");
+            });
+
+            it("matches arrays ending with the same elements", function() {
+                assert(sinonMatch.array.endsWith([2]).test([1, 2]));
+                assert(sinonMatch.array.endsWith([1, 2]).test([1, 2]));
+                assert.isFalse(
+                    sinonMatch.array.endsWith([1, 2, 3]).test([1, 2])
+                );
+                assert.isFalse(sinonMatch.array.endsWith([3]).test([1, 2]));
+            });
+
+            it("fails when passed a non-array object", function() {
+                var endsWith = sinonMatch.array.endsWith(["two", "three"]);
+
+                assert.isFalse(
+                    endsWith.test({ 0: "one", 1: "two", 2: "three", length: 3 })
+                );
+            });
+        });
+
+        describe("array.contains", function() {
+            it("has a .contains matcher", function() {
+                var contains = sinonMatch.array.contains([2, 3]);
+
+                assert(sinonMatch.isMatcher(contains));
+                assert.equals(contains.toString(), "contains([2,3])");
+            });
+
+            it("matches arrays containing all the expected elements", function() {
+                assert(sinonMatch.array.contains([2]).test([1, 2, 3]));
+                assert(sinonMatch.array.contains([1, 2]).test([1, 2]));
+                assert.isFalse(
+                    sinonMatch.array.contains([1, 2, 3]).test([1, 2])
+                );
+                assert.isFalse(sinonMatch.array.contains([3]).test([1, 2]));
+            });
+
+            it("fails when passed a non-array object", function() {
+                var contains = sinonMatch.array.contains(["one", "three"]);
+
+                assert.isFalse(
+                    contains.test({ 0: "one", 1: "two", 2: "three", length: 3 })
+                );
+            });
+        });
+    });
+
+    describe(".map", function() {
+        it("is typeOf map matcher", function() {
+            var map = sinonMatch.map;
+
+            assert(sinonMatch.isMatcher(map));
+            assert.equals(map.toString(), 'typeOf("map")');
+        });
+
+        describe("map.deepEquals", function() {
+            if (typeof Map === "function") {
+                it("has a .deepEquals matcher", function() {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var deepEquals = sinonMatch.map.deepEquals(mapOne);
+                    assert(sinonMatch.isMatcher(deepEquals));
+                    assert.equals(
+                        deepEquals.toString(),
+                        "deepEquals(Map[['one',1],['two',2],['three',3]])"
+                    );
+                });
+
+                it("matches maps with the exact same elements", function() {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var mapTwo = new Map();
+                    mapTwo.set("one", 1);
+                    mapTwo.set("two", 2);
+                    mapTwo.set("three", 3);
+
+                    var mapThree = new Map();
+                    mapThree.set("one", 1);
+                    mapThree.set("two", 2);
+
+                    var deepEquals = sinonMatch.map.deepEquals(mapOne);
+                    assert(deepEquals.test(mapTwo));
+                    assert.isFalse(deepEquals.test(mapThree));
+                    assert.isFalse(deepEquals.test(new Map()));
+                });
+
+                it("fails when maps have the same keys but different values", function() {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var mapTwo = new Map();
+                    mapTwo.set("one", 2);
+                    mapTwo.set("two", 4);
+                    mapTwo.set("three", 8);
+
+                    var mapThree = new Map();
+                    mapTwo.set("one", 1);
+                    mapTwo.set("two", 2);
+                    mapTwo.set("three", 4);
+
+                    var deepEquals = sinonMatch.map.deepEquals(mapOne);
+                    assert.isFalse(deepEquals.test(mapTwo));
+                    assert.isFalse(deepEquals.test(mapThree));
+                });
+
+                it("fails when passed a non-map object", function() {
+                    var deepEquals = sinonMatch.array.deepEquals(new Map());
+                    assert.isFalse(deepEquals.test({}));
+                    assert.isFalse(deepEquals.test([]));
+                });
+            }
+        });
+
+        describe("map.contains", function() {
+            if (typeof Map === "function") {
+                it("has a .contains matcher", function() {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var contains = sinonMatch.map.contains(mapOne);
+                    assert(sinonMatch.isMatcher(contains));
+                    assert.equals(
+                        contains.toString(),
+                        "contains(Map[['one',1],['two',2],['three',3]])"
+                    );
+                });
+
+                it("matches maps containing the given elements", function() {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var mapTwo = new Map();
+                    mapTwo.set("one", 1);
+                    mapTwo.set("two", 2);
+                    mapTwo.set("three", 3);
+
+                    var mapThree = new Map();
+                    mapThree.set("one", 1);
+                    mapThree.set("two", 2);
+
+                    var mapFour = new Map();
+                    mapFour.set("one", 1);
+                    mapFour.set("four", 4);
+
+                    assert(sinonMatch.map.contains(mapTwo).test(mapOne));
+                    assert(sinonMatch.map.contains(mapThree).test(mapOne));
+                    assert.isFalse(
+                        sinonMatch.map.contains(mapFour).test(mapOne)
+                    );
+                });
+
+                it("fails when maps contain the same keys but different values", function() {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var mapTwo = new Map();
+                    mapTwo.set("one", 2);
+                    mapTwo.set("two", 4);
+                    mapTwo.set("three", 8);
+
+                    var mapThree = new Map();
+                    mapThree.set("one", 1);
+                    mapThree.set("two", 2);
+                    mapThree.set("three", 4);
+
+                    assert.isFalse(
+                        sinonMatch.map.contains(mapTwo).test(mapOne)
+                    );
+                    assert.isFalse(
+                        sinonMatch.map.contains(mapThree).test(mapOne)
+                    );
+                });
+
+                it("fails when passed a non-map object", function() {
+                    var contains = sinonMatch.map.contains(new Map());
+                    assert.isFalse(contains.test({}));
+                    assert.isFalse(contains.test([]));
+                });
+            }
+        });
+    });
+
+    describe(".set", function() {
+        it("is typeOf set matcher", function() {
+            var set = sinonMatch.set;
+
+            assert(sinonMatch.isMatcher(set));
+            assert.equals(set.toString(), 'typeOf("set")');
+        });
+
+        describe("set.deepEquals", function() {
+            if (typeof Set === "function") {
+                it("has a .deepEquals matcher", function() {
+                    var setOne = new Set();
+                    setOne.add("one");
+                    setOne.add("two");
+                    setOne.add("three");
+
+                    var deepEquals = sinonMatch.set.deepEquals(setOne);
+                    assert(sinonMatch.isMatcher(deepEquals));
+                    assert.equals(
+                        deepEquals.toString(),
+                        "deepEquals(Set['one','two','three'])"
+                    );
+                });
+
+                it("matches sets with the exact same elements", function() {
+                    var setOne = new Set();
+                    setOne.add("one");
+                    setOne.add("two");
+                    setOne.add("three");
+
+                    var setTwo = new Set();
+                    setTwo.add("one");
+                    setTwo.add("two");
+                    setTwo.add("three");
+
+                    var setThree = new Set();
+                    setThree.add("one");
+                    setThree.add("two");
+
+                    var deepEquals = sinonMatch.set.deepEquals(setOne);
+                    assert(deepEquals.test(setTwo));
+                    assert.isFalse(deepEquals.test(setThree));
+                    assert.isFalse(deepEquals.test(new Set()));
+                });
+
+                it("fails when passed a non-set object", function() {
+                    var deepEquals = sinonMatch.array.deepEquals(new Set());
+                    assert.isFalse(deepEquals.test({}));
+                    assert.isFalse(deepEquals.test([]));
+                });
+            }
+        });
+
+        describe("set.contains", function() {
+            if (typeof Set === "function") {
+                it("has a .contains matcher", function() {
+                    var setOne = new Set();
+                    setOne.add("one");
+                    setOne.add("two");
+                    setOne.add("three");
+
+                    var contains = sinonMatch.set.contains(setOne);
+                    assert(sinonMatch.isMatcher(contains));
+                    assert.equals(
+                        contains.toString(),
+                        "contains(Set['one','two','three'])"
+                    );
+                });
+
+                it("matches sets containing the given elements", function() {
+                    var setOne = new Set();
+                    setOne.add("one");
+                    setOne.add("two");
+                    setOne.add("three");
+
+                    var setTwo = new Set();
+                    setTwo.add("one");
+                    setTwo.add("two");
+                    setTwo.add("three");
+
+                    var setThree = new Set();
+                    setThree.add("one");
+                    setThree.add("two");
+
+                    var setFour = new Set();
+                    setFour.add("one");
+                    setFour.add("four");
+
+                    assert(sinonMatch.set.contains(setTwo).test(setOne));
+                    assert(sinonMatch.set.contains(setThree).test(setOne));
+                    assert.isFalse(
+                        sinonMatch.set.contains(setFour).test(setOne)
+                    );
+                });
+
+                it("fails when passed a non-set object", function() {
+                    var contains = sinonMatch.set.contains(new Set());
+                    assert.isFalse(contains.test({}));
+                    assert.isFalse(contains.test([]));
+                });
+            }
+        });
+    });
+
+    describe(".regexp", function() {
+        it("is typeOf regexp matcher", function() {
+            var regexp = sinonMatch.regexp;
+
+            assert(sinonMatch.isMatcher(regexp));
+            assert.equals(regexp.toString(), 'typeOf("regexp")');
+        });
+    });
+
+    describe(".date", function() {
+        it("is typeOf regexp matcher", function() {
+            var date = sinonMatch.date;
+
+            assert(sinonMatch.isMatcher(date));
+            assert.equals(date.toString(), 'typeOf("date")');
+        });
+    });
+
+    describe(".symbol", function() {
+        it("is typeOf symbol matcher", function() {
+            var symbol = sinonMatch.symbol;
+
+            assert(sinonMatch.isMatcher(symbol));
+            assert.equals(symbol.toString(), 'typeOf("symbol")');
+        });
+    });
+
+    describe(".or", function() {
+        it("is matcher", function() {
+            var numberOrString = sinonMatch.number.or(sinonMatch.string);
+
+            assert(sinonMatch.isMatcher(numberOrString));
+            assert.equals(
+                numberOrString.toString(),
+                'typeOf("number").or(typeOf("string"))'
+            );
+        });
+
+        it("requires matcher argument", function() {
+            assert.exception(
+                function() {
+                    sinonMatch.instanceOf(Error).or();
+                },
+                { name: "TypeError" }
+            );
+        });
+
+        it("will coerce argument to matcher", function() {
+            var abcOrDef = sinonMatch("abc").or("def");
+
+            assert(sinonMatch.isMatcher(abcOrDef));
+            assert.equals(abcOrDef.toString(), 'match("abc").or(match("def"))');
+        });
+
+        it("returns true if either matcher matches", function() {
+            var numberOrString = sinonMatch.number.or(sinonMatch.string);
+
+            assert(numberOrString.test(123));
+            assert(numberOrString.test("abc"));
+        });
+
+        it("returns false if neither matcher matches", function() {
+            var numberOrAbc = sinonMatch.number.or("abc");
+
+            assert.isFalse(numberOrAbc.test(/.+/));
+            assert.isFalse(numberOrAbc.test(new Date()));
+            assert.isFalse(numberOrAbc.test({}));
+        });
+
+        it("can be used with undefined", function() {
+            var numberOrUndef = sinonMatch.number.or(undefined);
+
+            assert(numberOrUndef.test(123));
+            assert(numberOrUndef.test(undefined));
+        });
+    });
+
+    describe(".and", function() {
+        it("is matcher", function() {
+            var fooAndBar = sinonMatch.has("foo").and(sinonMatch.has("bar"));
+
+            assert(sinonMatch.isMatcher(fooAndBar));
+            assert.equals(fooAndBar.toString(), 'has("foo").and(has("bar"))');
+        });
+
+        it("requires matcher argument", function() {
+            assert.exception(
+                function() {
+                    sinonMatch.instanceOf(Error).and();
+                },
+                { name: "TypeError" }
+            );
+        });
+
+        it("will coerce to matcher", function() {
+            var abcOrObj = sinonMatch("abc").or({ a: 1 });
+
+            assert(sinonMatch.isMatcher(abcOrObj));
+            assert.equals(abcOrObj.toString(), 'match("abc").or(match(a: 1))');
+        });
+
+        it("returns true if both matchers match", function() {
+            var fooAndBar = sinonMatch.has("foo").and({ bar: "bar" });
+
+            assert(fooAndBar.test({ foo: "foo", bar: "bar" }));
+        });
+
+        it("returns false if either matcher does not match", function() {
+            var fooAndBar = sinonMatch.has("foo").and(sinonMatch.has("bar"));
+
+            assert.isFalse(fooAndBar.test({ foo: "foo" }));
+            assert.isFalse(fooAndBar.test({ bar: "bar" }));
+        });
+
+        it("can be used with undefined", function() {
+            var falsyAndUndefined = sinonMatch.falsy.and(undefined);
+
+            assert.isFalse(falsyAndUndefined.test(false));
+            assert(falsyAndUndefined.test(undefined));
+        });
+    });
+
+    describe("nested", function() {
+        it("returns true for an object with nested matcher", function() {
+            var match = sinonMatch({ outer: sinonMatch({ inner: "sinon" }) });
+
+            assert.isTrue(
+                match.test({ outer: { inner: "sinon", foo: "bar" } })
+            );
+        });
+
+        it("returns true for an array of nested matchers", function() {
+            var match = sinonMatch([sinonMatch({ str: "sinon" })]);
+
+            assert.isTrue(match.test([{ str: "sinon", foo: "bar" }]));
+        });
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4275,6 +4275,11 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
+      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
     "@sinonjs/referee": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-2.0.0.tgz",
@@ -279,6 +287,11 @@
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "array-map": {
       "version": "0.0.0",
@@ -9804,6 +9817,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   ],
   "dependencies": {
     "@sinonjs/commons": "1.0.2",
-    "array-from": "^2.1.1"
+    "array-from": "^2.1.1",
+    "lodash.get": "4.4.2"
   },
   "devDependencies": {
     "@sinonjs/referee": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "lib/",
     "!lib/**/*.test.js"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "@sinonjs/commons": "1.0.2",
+    "array-from": "^2.1.1"
+  },
   "devDependencies": {
     "@sinonjs/referee": "^2.0.0",
     "benchmark": "2.1.4",


### PR DESCRIPTION
This PR is a ⚠️ work in progress ⚠️, and is a partial solution to https://github.com/sinonjs/referee/issues/29

The imported `sinon-match` is not exported yet, this is just to make sure we can actually import it and run the tests.

#### How to verify - mandatory

1. In your `@sinonjs/commons` clone, checkout https://github.com/sinonjs/commons/pull/3
1. `npm link`
1. In your `@sinonjs/samsam` clone, check out this branch
1. `npm install`
1. `npm link @sinonjs/commons`
1. `npm test`
1. Observe that there's just one failing test
1. Soon™️

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).