### PR TITLE
feat(deepEqual): compare constructor name of objects

### DIFF
--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -9,6 +9,7 @@ var isNaN = require("./is-nan");
 var isObject = require("./is-object");
 var isSet = require("./is-set");
 var isSubset = require("./is-subset");
+var getClassName = require("./get-class-name");
 
 var every = Array.prototype.every;
 var getTime = Date.prototype.getTime;
@@ -96,6 +97,8 @@ function deepEqualCyclic(first, second) {
         var class2 = getClass(obj2);
         var keys1 = keys(obj1);
         var keys2 = keys(obj2);
+        var name1 = getClassName(obj1);
+        var name2 = getClassName(obj2);
 
         if (isArguments(obj1) || isArguments(obj2)) {
             if (obj1.length !== obj2.length) {
@@ -105,7 +108,8 @@ function deepEqualCyclic(first, second) {
             if (
                 type1 !== type2 ||
                 class1 !== class2 ||
-                keys1.length !== keys2.length
+                keys1.length !== keys2.length ||
+                (!!name1 && name2 && name1 !== name2)
             ) {
                 return false;
             }

--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -109,7 +109,7 @@ function deepEqualCyclic(first, second) {
                 type1 !== type2 ||
                 class1 !== class2 ||
                 keys1.length !== keys2.length ||
-                (!!name1 && name2 && name1 !== name2)
+                (name1 && name2 && name1 !== name2)
             ) {
                 return false;
             }

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -414,7 +414,7 @@ describe("deepEqual", function() {
         assert.isTrue(samsam.deepEqual(element, element));
     });
 
-    it("return false if empty opject to empty instance", function() {
+    it("return false if empty object to empty instance", function() {
         // Because eslint-config-sinon disables es6, we can't
         // use a class definition here
         // https://github.com/sinonjs/eslint-config-sinon/blob/master/index.js

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -414,6 +414,15 @@ describe("deepEqual", function() {
         assert.isTrue(samsam.deepEqual(element, element));
     });
 
+    it("return false if empty opject to empty instance", function() {
+        // Because eslint-config-sinon disables es6, we can't
+        // use a class definition here
+        // https://github.com/sinonjs/eslint-config-sinon/blob/master/index.js
+        // var instance = new (class TestClass {});
+        var instance = new function TestClass() {}();
+        assert.isFalse(samsam.deepEqual(obj, instance));
+    });
+
     it("fails different DOM elements", function() {
         var element = document.createElement("div");
         var el = document.createElement("div");

--- a/lib/get-class-name.js
+++ b/lib/get-class-name.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function getClassName(value) {
+    return Object.getPrototypeOf(value) ? value.constructor.name : null;
+}
+
+module.exports = getClassName;

--- a/lib/get-class-name.test.js
+++ b/lib/get-class-name.test.js
@@ -14,7 +14,7 @@ describe("getClassName", function() {
         assert.equals(name, "TestClass");
     });
 
-    it("returns the Object for {}", function() {
+    it("returns 'Object' for {}", function() {
         var name = getClassName({});
         assert.equals(name, "Object");
     });

--- a/lib/get-class-name.test.js
+++ b/lib/get-class-name.test.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var assert = require("@sinonjs/referee").assert;
+var getClassName = require("./get-class-name");
+
+describe("getClassName", function() {
+    it("returns the class name of an instance", function() {
+        // Because eslint-config-sinon disables es6, we can't
+        // use a class definition here
+        // https://github.com/sinonjs/eslint-config-sinon/blob/master/index.js
+        // var instance = new (class TestClass {})();
+        var instance = new function TestClass() {}();
+        var name = getClassName(instance);
+        assert.equals(name, "TestClass");
+    });
+
+    it("returns the Object for {}", function() {
+        var name = getClassName({});
+        assert.equals(name, "Object");
+    });
+
+    it("returns null for an object that has no prototype", function() {
+        var obj = Object.create(null);
+        var name = getClassName(obj);
+        assert.equals(name, null);
+    });
+});


### PR DESCRIPTION
#### Purpose  (TL;DR)
This feature adds the comparision of the `name` property of a given objects `constructor` if there is any.

See #37, sinonjs/sinon#1882

#### Solution

Check if the names of the constructor of two given objects are unequal and return `false` if so. This is done by a helper function `getClassName()` which returns the name of the constructor or `null`.


#### How to verify
1. Check out this branch
2. `npm install`
3. `npm run test`

#### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
