### PR TITLE
Fix getting class name of Node v6 querystring object

### DIFF
--- a/lib/get-class-name.js
+++ b/lib/get-class-name.js
@@ -1,7 +1,7 @@
 "use strict";
 
 function getClassName(value) {
-    return Object.getPrototypeOf(value) ? value.constructor.name : null;
+    return value.constructor ? value.constructor.name : null;
 }
 
 module.exports = getClassName;

--- a/lib/get-class-name.test.js
+++ b/lib/get-class-name.test.js
@@ -24,4 +24,13 @@ describe("getClassName", function() {
         var name = getClassName(obj);
         assert.equals(name, null);
     });
+
+    it("returns null for an object whose prototype was mangled", function() {
+        // This is what Node v6 and v7 do for objects returned by querystring.parse()
+        function MangledObject() {}
+        MangledObject.prototype = Object.create(null);
+        var obj = new MangledObject();
+        var name = getClassName(obj);
+        assert.equals(name, null);
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
getClassName() does not currently work with objects returned by the Node v6 querystring builtin module, which does some weird things to the object.  When run on those objects, the module throws an exception, since `value.constructor` is `undefined`, even though the object does have a prototype defined.  This is breaking sinon mock expectations against those types of objects for us.

See https://github.com/nodejs/node/blob/v6.x/lib/querystring.js#L20

#### Solution  - optional

If what this library wants to return is the constructor name, I think it would be simpler just to check if that exists and return that.  In this case, I believe that `null` is the correct return type, since the object is not intended to represent a specific instance (and in more recent versions of Node, `querystring.parse()` just uses `Object.create(null)` directly).

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
