### PR TITLE
Handle null match argument

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -89,6 +89,9 @@ function match(object, matcher) {
         if (matcher === object) {
             return true;
         }
+        if (typeof object !== "object") {
+            return false;
+        }
         var prop;
         // eslint-disable-next-line guard-for-in
         for (prop in matcher) {

--- a/lib/match.js
+++ b/lib/match.js
@@ -69,6 +69,10 @@ function match(object, matcher) {
         return object === null;
     }
 
+    if (object === null) {
+        return false;
+    }
+
     if (isSet(object)) {
         return isSubset(matcher, object, match);
     }

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -139,6 +139,16 @@ describe("match", function() {
         assert.isFalse(checkMatch);
     });
 
+    it("returns false if null and empty object", function() {
+        var checkMatch = samsam.match(null, {});
+        assert.isFalse(checkMatch);
+    });
+
+    it("returns false if null and object with properties", function() {
+        var checkMatch = samsam.match(null, { not: 1 });
+        assert.isFalse(checkMatch);
+    });
+
     it("returns false if undefined and empty string", function() {
         var checkMatch = samsam.match(undefined, "");
         assert.isFalse(checkMatch);

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -154,8 +154,18 @@ describe("match", function() {
         assert.isFalse(checkMatch);
     });
 
+    it("returns false if undefined and empty object", function() {
+        var checkMatch = samsam.match(undefined, {});
+        assert.isFalse(checkMatch);
+    });
+
     it("returns false if false and empty string", function() {
         var checkMatch = samsam.match(false, "");
+        assert.isFalse(checkMatch);
+    });
+
+    it("returns false if false and empty object", function() {
+        var checkMatch = samsam.match(false, {});
         assert.isFalse(checkMatch);
     });
 
@@ -164,8 +174,18 @@ describe("match", function() {
         assert.isFalse(checkMatch);
     });
 
+    it("returns false if 0 and empty object", function() {
+        var checkMatch = samsam.match(0, {});
+        assert.isFalse(checkMatch);
+    });
+
     it("returns false if NaN and empty string", function() {
         var checkMatch = samsam.match(NaN, "");
+        assert.isFalse(checkMatch);
+    });
+
+    it("returns false if NaN and empty object", function() {
+        var checkMatch = samsam.match(NaN, {});
         assert.isFalse(checkMatch);
     });
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

 This fixes an issue where `samsam.match(null, { not: 1 })` would throw `TypeError: Cannot read property 'not' of null`.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).