### PR TITLE
Fix nested array match

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var deepEqual = require("./deep-equal").use(match); // eslint-disable-line no-use-before-define
 var getClass = require("./get-class");
 var isDate = require("./is-date");
 var isSet = require("./is-set");
@@ -112,7 +113,7 @@ function match(object, matcher) {
                 }
             } else if (
                 typeof value === "undefined" ||
-                !match(value, matcher[prop])
+                !deepEqual(value, matcher[prop])
             ) {
                 return false;
             }

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -206,6 +206,16 @@ describe("match", function() {
         assert.isTrue(checkMatch);
     });
 
+    it("returns false if nested array has more properties", function() {
+        var object = {
+            nested: [1, 2, 3]
+        };
+        var checkMatch = samsam.match(object, {
+            nested: [2]
+        });
+        assert.isFalse(checkMatch);
+    });
+
     it("returns true if nested matcher", function() {
         var object = {
             id: 42,
@@ -223,9 +233,9 @@ describe("match", function() {
         var checkMatch = samsam.match(object, {
             owner: {
                 someDude: "Yes",
-                hello: function(value) {
+                hello: samsam.createMatcher(function(value) {
                     return value === "ok";
-                }
+                })
             }
         });
         assert.isTrue(checkMatch);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

__BREAKING:__ This brings the `samsam.match` implementation closer to how `sinon.match` behaves. Nested object where recursively compared using `samsam.match` itself. This change uses `samsam.deepEqual` for recursive checks instead. If matching logic is desireable on nested objects, `samsam.createMatcher` can be used which is now recognized.

#### Background (Problem in detail)  - optional

This fixes https://github.com/sinonjs/referee/issues/54

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
