### PR TITLE
Fix Error instance comparison for IE11

### DIFF
--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -98,13 +98,7 @@ function deepEqualCyclic(first, second, match) {
         }
 
         if (obj1 instanceof Error && obj2 instanceof Error) {
-            if (
-                obj1.constructor !== obj2.constructor ||
-                obj1.message !== obj2.message ||
-                obj1.stack !== obj2.stack
-            ) {
-                return false;
-            }
+            return obj1 === obj2;
         }
 
         var class1 = getClass(obj1);

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -475,6 +475,13 @@ describe("deepEqual", function() {
         assert.equals(el.childNodes.length, 0);
     });
 
+    it("fails unequal errors", function() {
+        var error1 = new Error();
+        var error2 = new Error();
+
+        assert.isFalse(samsam.deepEqual(error1, error2));
+    });
+
     if (typeof Set !== "undefined") {
         it("returns true if set with the same content", function() {
             var checkDeep = samsam.deepEqual(


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

The comparison logic for `Error` instances was broken for IE11. I can't think of a reason why we should keep comparing the error properties instead of the instances directly.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run test-cloud`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
