### PR TITLE
Depend on version ranges rather than exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "!lib/**/*.test.js"
   ],
   "dependencies": {
-    "@sinonjs/commons": "1.0.2",
+    "@sinonjs/commons": "^1.0.2",
     "array-from": "^2.1.1",
-    "lodash.get": "4.4.2"
+    "lodash.get": "^4.4.2"
   },
   "devDependencies": {
     "@sinonjs/referee": "^2.0.0",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Currently, samsam depends on exact versions of `@sinonjs/commons` and `lodash.get`, which prevents npm from deduping those packages if other, compatible versions of them are dependents of other packages in the tree.

For example, sinon currently [depends on](https://github.com/sinonjs/sinon/blob/9741f41f94d45785daed11a129c080ea04f7f78e/package.json#L58) `@sinonjs/commons@^1.2.0`, meaning that `npm install sinon` unnecessarily installs two different versions of `@sinonjs/commons`.

Generally, unless there's a specific reason to pin dependencies to exact versions, could sinon and its associated libraries try to depend on version ranges instead?

(Incidentally, Lodash's compiled zero-dependency packages are considered [deprecated](https://github.com/lodash/lodash/wiki/Roadmap#v500-2018) in favor of modular imports from the main Lodash package, so `lodash.get` should be replaced with `lodash/get`. Happy to PR that as well, if you'd like.)

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Run tests

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
