### PR TITLE
Improve deep equality matching on arrays

### DIFF
--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -349,7 +349,8 @@ match.array.deepEquals = function(expectation) {
             sameLength &&
             every(actual, function(element, index) {
                 var expected = expectation[index];
-                return Array.isArray(expected) && Array.isArray(element)
+                return typeOf(expected) === "array" &&
+                    typeOf(element) === "array"
                     ? match.array.deepEquals(expected).test(element)
                     : expected === element;
             })

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -348,7 +348,10 @@ match.array.deepEquals = function(expectation) {
             typeOf(actual) === "array" &&
             sameLength &&
             every(actual, function(element, index) {
-                return expectation[index] === element;
+                var expected = expectation[index];
+                return Array.isArray(expected) && Array.isArray(element)
+                    ? match.array.deepEquals(expected).test(element)
+                    : expected === element;
             })
         );
     }, "deepEquals([" + iterableToString(expectation) + "])");

--- a/lib/matcher.test.js
+++ b/lib/matcher.test.js
@@ -930,16 +930,42 @@ describe("matcher", function() {
                 assert.equals(deepEquals.toString(), "deepEquals([1,2,3])");
             });
 
-            it("should match nested arrays", function() {
-                var deepEquals = createMatcher.array.deepEquals([["test"]]);
-                assert(deepEquals.test([["test"]]));
+            describe("one-dimensional arrays", function() {
+                it("matches arrays with the exact same elements", function() {
+                    var deepEquals = createMatcher.array.deepEquals([1, 2, 3]);
+                    assert(deepEquals.test([1, 2, 3]));
+                    assert.isFalse(deepEquals.test([1, 2]));
+                    assert.isFalse(deepEquals.test([3]));
+                });
             });
 
-            it("matches arrays with the exact same elements", function() {
-                var deepEquals = createMatcher.array.deepEquals([1, 2, 3]);
-                assert(deepEquals.test([1, 2, 3]));
-                assert.isFalse(deepEquals.test([1, 2]));
-                assert.isFalse(deepEquals.test([3]));
+            describe("nested arrays", function() {
+                var deepEquals;
+                beforeEach(function() {
+                    deepEquals = createMatcher.array.deepEquals([
+                        ["test"],
+                        ["nested"],
+                        ["arrays"]
+                    ]);
+                });
+                it("matches nested arrays with the exact same elements", function() {
+                    assert(deepEquals.test([["test"], ["nested"], ["arrays"]]));
+                });
+
+                it("fails when nested arrays are not in the same order", function() {
+                    assert.isFalse(
+                        deepEquals.test([["test"], ["arrays"], ["nested"]])
+                    );
+                });
+
+                it("fails when nested arrays don't have same count", function() {
+                    assert.isFalse(deepEquals.test([["test"], ["arrays"]]));
+                });
+
+                it("matches nested, empty arrays", function() {
+                    var empty = createMatcher.array.deepEquals([[], []]);
+                    assert.isTrue(empty.test([[], []]));
+                });
             });
 
             it("fails when passed a non-array object", function() {

--- a/lib/matcher.test.js
+++ b/lib/matcher.test.js
@@ -930,6 +930,11 @@ describe("matcher", function() {
                 assert.equals(deepEquals.toString(), "deepEquals([1,2,3])");
             });
 
+            it("should match nested arrays", function() {
+                var deepEquals = createMatcher.array.deepEquals([["test"]]);
+                assert(deepEquals.test([["test"]]));
+            });
+
             it("matches arrays with the exact same elements", function() {
                 var deepEquals = createMatcher.array.deepEquals([1, 2, 3]);
                 assert(deepEquals.test([1, 2, 3]));


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This PR is intended to study and improve the behaviour of matching arrays `deepEqual`.

First this just adds a failing testcase for nested arrays as described in #54.

Improved `array.deepEquals` to call itself when given an array as `element`. All other elements will be checked by stricked equality (`===`) as usual.

*Note:* I used `Array.isArray` to determine if an element is an array. I am not quite sure if this is a prefered way to do so ❓ 😕 

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
