### PR TITLE
Some improvements

### DIFF
--- a/lib/create-set.js
+++ b/lib/create-set.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var typeOf = require("@sinonjs/commons").typeOf;
+
 // This helper makes it convenient to create Set instances from a
 // collection, an overcomes the shortcoming that IE11 doesn't support
 // collection arguments
@@ -12,7 +14,7 @@ function createSet(array) {
         );
     }
 
-    var items = Array.isArray(array) ? array : [];
+    var items = typeOf(array) === "array" ? array : [];
     var set = new Set();
 
     items.forEach(function(item) {

--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var valueToString = require("@sinonjs/commons").valueToString;
+
 var getClass = require("./get-class");
 var identical = require("./identical");
 var isArguments = require("./is-arguments");
@@ -92,7 +94,7 @@ function deepEqualCyclic(first, second, match) {
         }
 
         if (obj1 instanceof RegExp && obj2 instanceof RegExp) {
-            if (obj1.toString() !== obj2.toString()) {
+            if (valueToString(obj1) !== valueToString(obj2)) {
                 return false;
             }
         }

--- a/lib/get-class-name.js
+++ b/lib/get-class-name.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var valueToString = require("@sinonjs/commons").valueToString;
+
 var re = /function (\w+)\s*\(/;
 
 function getClassName(value) {
@@ -8,7 +10,7 @@ function getClassName(value) {
     }
 
     if (typeof value.constructor === "function") {
-        var match = value.constructor.toString().match(re);
+        var match = valueToString(value.constructor).match(re);
         if (match.length > 1) {
             return match[1];
         }

--- a/lib/iterable-to-string.js
+++ b/lib/iterable-to-string.js
@@ -2,12 +2,15 @@
 
 var slice = require("@sinonjs/commons").prototypes.string.slice;
 var typeOf = require("@sinonjs/commons").typeOf;
+var valueToString = require("@sinonjs/commons").valueToString;
 
 module.exports = function iterableToString(obj) {
     var representation = "";
 
     function stringify(item) {
-        return typeof item === "string" ? "'" + item + "'" : String(item);
+        return typeof item === "string"
+            ? "'" + item + "'"
+            : valueToString(item);
     }
 
     function mapToString(map) {

--- a/lib/match.js
+++ b/lib/match.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var valueToString = require("@sinonjs/commons").valueToString;
+
 var deepEqual = require("./deep-equal").use(match); // eslint-disable-line no-use-before-define
 var getClass = require("./get-class");
 var isDate = require("./is-date");
@@ -49,7 +51,7 @@ function match(object, matcher) {
         var notNull = typeof object === "string" || !!object;
         return (
             notNull &&
-            String(object)
+            valueToString(object)
                 .toLowerCase()
                 .indexOf(matcher) >= 0
         );

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -202,7 +202,7 @@ match.same = function(expectation) {
 };
 
 match.in = function(arrayOfExpectations) {
-    if (!Array.isArray(arrayOfExpectations)) {
+    if (typeOf(arrayOfExpectations) !== "array") {
         throw new TypeError("array expected");
     }
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
While working on #55 we found some places where we can use functionality from the `@sinonjs/commons` package.

- Strigngs
  - Replace `someVar.toString()` with `valueToString(someVar)`
  - Replace `String(someVar)` with `valueToString(someVar)`
- Arrays
  - Replace `Array.isArray(someVar)`

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
