### PR TITLE
refactor: use deepEqual for array elements

### DIFF
--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -352,7 +352,7 @@ match.array.deepEquals = function(expectation) {
                 return typeOf(expected) === "array" &&
                     typeOf(element) === "array"
                     ? match.array.deepEquals(expected).test(element)
-                    : expected === element;
+                    : deepEqual(expected, element);
             })
         );
     }, "deepEquals([" + iterableToString(expectation) + "])");

--- a/lib/matcher.test.js
+++ b/lib/matcher.test.js
@@ -945,16 +945,29 @@ describe("matcher", function() {
                     deepEquals = createMatcher.array.deepEquals([
                         ["test"],
                         ["nested"],
-                        ["arrays"]
+                        ["arrays"],
+                        [{ with: "object" }]
                     ]);
                 });
                 it("matches nested arrays with the exact same elements", function() {
-                    assert(deepEquals.test([["test"], ["nested"], ["arrays"]]));
+                    assert(
+                        deepEquals.test([
+                            ["test"],
+                            ["nested"],
+                            ["arrays"],
+                            [{ with: "object" }]
+                        ])
+                    );
                 });
 
                 it("fails when nested arrays are not in the same order", function() {
                     assert.isFalse(
-                        deepEquals.test([["test"], ["arrays"], ["nested"]])
+                        deepEquals.test([
+                            ["test"],
+                            ["arrays"],
+                            ["nested"],
+                            [{ with: "object" }]
+                        ])
                     );
                 });
 


### PR DESCRIPTION
#### Purpose (TL;DR)

use the `deepEqual` function for `expected` and `actual` element when comparing arrays.

Also extend test case for nested arrays

#### Background (Problem in detail)  - optional

See #54 #55 


#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
