### PR TITLE
feat: export isSet method

### DIFF
--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -4,6 +4,7 @@ var identical = require("./identical");
 var isArguments = require("./is-arguments");
 var isElement = require("./is-element");
 var isNegZero = require("./is-neg-zero");
+var isSet = require("./is-set");
 var match = require("./match");
 var deepEqualCyclic = require("./deep-equal").use(match);
 var createMatcher = require("./matcher");
@@ -11,9 +12,10 @@ var createMatcher = require("./matcher");
 module.exports = {
     createMatcher: createMatcher,
     deepEqual: deepEqualCyclic,
+    identical: identical,
     isArguments: isArguments,
     isElement: isElement,
     isNegZero: isNegZero,
-    identical: identical,
+    isSet: isSet,
     match: match
 };


### PR DESCRIPTION


#### Purpose (TL;DR) - mandatory
This is for a possible refactoring in formatio to use the provided isSet method
from samsam
See: sinonjs/formatio#22


#### Background (Problem in detail)  - optional

Use `isSet` method in [formatio](https://github.com/sinonjs/formatio/blob/07e2b54e573a199b1006dd223160c66bca3eb870/lib/formatio.js#L88) to reduce code duplication.


#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
