### PR TITLE
Check createMatcher arguments

### DIFF
--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -132,6 +132,10 @@ function match(expectation, message) {
     var m = Object.create(matcher);
     var type = typeOf(expectation);
 
+    if (message !== undefined && typeof message !== "string") {
+        throw new TypeError("Message should be a string");
+    }
+
     if (type in TYPE_MAP) {
         TYPE_MAP[type](m, expectation, message);
     } else {

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -136,6 +136,12 @@ function match(expectation, message) {
         throw new TypeError("Message should be a string");
     }
 
+    if (arguments.length > 2) {
+        throw new TypeError(
+            "Expected 1 or 2 arguments, received " + arguments.length
+        );
+    }
+
     if (type in TYPE_MAP) {
         TYPE_MAP[type](m, expectation, message);
     } else {

--- a/lib/matcher.test.js
+++ b/lib/matcher.test.js
@@ -90,6 +90,13 @@ describe("matcher", function() {
         assert(createMatcher.isMatcher(match));
     });
 
+    it("throws for non-string message arguments", function() {
+        var iAmNotAString = {};
+        assert.exception(function() {
+            createMatcher(function() {}, iAmNotAString);
+        });
+    });
+
     it("exposes test function", function() {
         var test = function() {};
 

--- a/lib/matcher.test.js
+++ b/lib/matcher.test.js
@@ -97,6 +97,12 @@ describe("matcher", function() {
         });
     });
 
+    it("throws for superfluous arguments", function() {
+        assert.exception(function() {
+            createMatcher(function() {}, "error msg", "needless argument");
+        });
+    });
+
     it("exposes test function", function() {
         var test = function() {};
 


### PR DESCRIPTION
#### Purpose (TL;DR)

The signature for `samsam.createMatcher` is `createMatcher(expectation[, message])`. But since we don't type check the optional `message` argument (or the existence of subsequent arguments) there is no protection against mistakes like doing...

```javascript
sinon.assert.calledWith(
    myService,
    sinon.match(myCustomMatcher, sinon.match.func) // <--- wrongly placed parens
);
```

...instead of...

```javascript
sinon.assert.calledWith(
    myService,
    sinon.match(myCustomMatcher),
    sinon.match.func
);
```

This PR adds the missing checks.

#### How to verify
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
