### PR TITLE
Fix Symbol related tests for IE 11

### DIFF
--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -364,8 +364,16 @@ describe("deepEqual", function() {
         assert.isFalse(checkDeep);
     });
 
-    if (typeof Symbol === "symbol") {
-        var symbol = Symbol("id");
+    context("with symbol properties", function() {
+        var symbol;
+
+        before(function() {
+            if (typeof Symbol === "function") {
+                symbol = Symbol("id");
+            } else {
+                this.skip();
+            }
+        });
 
         it("returns false if object has different symbolic properties", function() {
             var obj1 = {};
@@ -400,7 +408,7 @@ describe("deepEqual", function() {
             var checkDeep = samsam.deepEqual(obj1, obj2);
             assert.isTrue(checkDeep);
         });
-    }
+    });
 
     it("returns false if object to null", function() {
         var checkDeep = samsam.deepEqual({}, null);
@@ -452,7 +460,13 @@ describe("deepEqual", function() {
         assert.isFalse(checkDeep);
     });
 
-    if (typeof Symbol === "symbol") {
+    context("with arguments expectation", function() {
+        before(function() {
+            if (typeof Symbol !== "function") {
+                this.skip();
+            }
+        });
+
         it("returns false if array to arguments", function() {
             var gather = function() {
                 return arguments;
@@ -472,7 +486,7 @@ describe("deepEqual", function() {
             var checkDeep = samsam.deepEqual(arrayLike, gather(1, 2, {}, []));
             assert.isFalse(checkDeep);
         });
-    }
+    });
 
     it("returns true if arguments to array", function() {
         var gather = function() {

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -26,7 +26,6 @@ describe("deepEqual", function() {
     var func = function() {};
     var obj = {};
     var arr = [];
-    var symbol = Symbol("id");
     var date = new Date();
     var sameDate = new Date(date.getTime());
     var sameDateWithProp = new Date(date.getTime());
@@ -365,39 +364,43 @@ describe("deepEqual", function() {
         assert.isFalse(checkDeep);
     });
 
-    it("returns false if object has different symbolic properties", function() {
-        var obj1 = {};
-        var obj2 = {};
-        obj1[symbol] = 42;
-        obj2[symbol] = 43;
-        var checkDeep = samsam.deepEqual(obj1, obj2);
-        assert.isFalse(checkDeep);
-    });
+    if (typeof Symbol === "symbol") {
+        var symbol = Symbol("id");
 
-    it("returns true if object has same symbolic properties", function() {
-        var obj1 = {};
-        var obj2 = {};
-        obj1[symbol] = 42;
-        obj2[symbol] = 42;
-        var checkDeep = samsam.deepEqual(obj1, obj2);
-        assert.isTrue(checkDeep);
-    });
+        it("returns false if object has different symbolic properties", function() {
+            var obj1 = {};
+            var obj2 = {};
+            obj1[symbol] = 42;
+            obj2[symbol] = 43;
+            var checkDeep = samsam.deepEqual(obj1, obj2);
+            assert.isFalse(checkDeep);
+        });
 
-    it("returns false if object missing expected symbolic properties", function() {
-        var obj1 = {};
-        var obj2 = {};
-        obj2[symbol] = 42;
-        var checkDeep = samsam.deepEqual(obj1, obj2);
-        assert.isFalse(checkDeep);
-    });
+        it("returns true if object has same symbolic properties", function() {
+            var obj1 = {};
+            var obj2 = {};
+            obj1[symbol] = 42;
+            obj2[symbol] = 42;
+            var checkDeep = samsam.deepEqual(obj1, obj2);
+            assert.isTrue(checkDeep);
+        });
 
-    it("returns true if object contains additional symbolic properties", function() {
-        var obj1 = {};
-        var obj2 = {};
-        obj1[symbol] = 42;
-        var checkDeep = samsam.deepEqual(obj1, obj2);
-        assert.isTrue(checkDeep);
-    });
+        it("returns false if object missing expected symbolic properties", function() {
+            var obj1 = {};
+            var obj2 = {};
+            obj2[symbol] = 42;
+            var checkDeep = samsam.deepEqual(obj1, obj2);
+            assert.isFalse(checkDeep);
+        });
+
+        it("returns true if object contains additional symbolic properties", function() {
+            var obj1 = {};
+            var obj2 = {};
+            obj1[symbol] = 42;
+            var checkDeep = samsam.deepEqual(obj1, obj2);
+            assert.isTrue(checkDeep);
+        });
+    }
 
     it("returns false if object to null", function() {
         var checkDeep = samsam.deepEqual({}, null);
@@ -449,15 +452,29 @@ describe("deepEqual", function() {
         assert.isFalse(checkDeep);
     });
 
-    it("returns false if arguments to array", function() {
-        var gather = function() {
-            return arguments;
-        };
-        var checkDeep = samsam.deepEqual([1, 2, {}, []], gather(1, 2, {}, []));
-        assert.isFalse(checkDeep);
-    });
+    if (typeof Symbol === "symbol") {
+        it("returns false if array to arguments", function() {
+            var gather = function() {
+                return arguments;
+            };
+            var checkDeep = samsam.deepEqual(
+                [1, 2, {}, []],
+                gather(1, 2, {}, [])
+            );
+            assert.isFalse(checkDeep);
+        });
 
-    it("returns true if array to arguments", function() {
+        it("returns false if array like object to arguments", function() {
+            var gather = function() {
+                return arguments;
+            };
+            var arrayLike = { length: 4, "0": 1, "1": 2, "2": {}, "3": [] };
+            var checkDeep = samsam.deepEqual(arrayLike, gather(1, 2, {}, []));
+            assert.isFalse(checkDeep);
+        });
+    }
+
+    it("returns true if arguments to array", function() {
         var gather = function() {
             return arguments;
         };
@@ -465,13 +482,13 @@ describe("deepEqual", function() {
         assert.isTrue(checkDeep);
     });
 
-    it("returns false if arguments to array like object", function() {
+    it("returns true if arguments to array like object", function() {
         var gather = function() {
             return arguments;
         };
         var arrayLike = { length: 4, "0": 1, "1": 2, "2": {}, "3": [] };
-        var checkDeep = samsam.deepEqual(arrayLike, gather(1, 2, {}, []));
-        assert.isFalse(checkDeep);
+        var checkDeep = samsam.deepEqual(gather(1, 2, {}, []), arrayLike);
+        assert.isTrue(checkDeep);
     });
 
     it("returns true for same error", function() {

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -364,7 +364,7 @@ describe("deepEqual", function() {
         assert.isFalse(checkDeep);
     });
 
-    context("with symbol properties", function() {
+    describe("with symbol properties", function() {
         var symbol;
 
         before(function() {
@@ -460,7 +460,7 @@ describe("deepEqual", function() {
         assert.isFalse(checkDeep);
     });
 
-    context("with arguments expectation", function() {
+    describe("with arguments expectation", function() {
         before(function() {
             if (typeof Symbol !== "function") {
                 this.skip();


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fixes test cases that broke due to #64.

#### Background (Problem in detail)  - optional

The reason the build on the PR did not break was that the browser tests don't run on PRs from forks. They only run on PRs from branches. This is due to some security constraints with our secret key for SauceLabs.

#### Solution  - optional

Feature detecting `Symbol` and conditionally execute the corresponding tests.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run test-cloud`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).