### PR TITLE
Use cached `getOwnPropertySymbols` consistently

### DIFF
--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -116,7 +116,7 @@ function deepEqualCyclic(actual, expectation, match) {
         var actualName = getClassName(actualObj);
         var expectationName = getClassName(expectationObj);
         var expectationSymbols =
-            typeof Object.getOwnPropertySymbols === "function"
+            typeof getOwnPropertySymbols === "function"
                 ? getOwnPropertySymbols(expectationObj)
                 : [];
         var expectationKeysAndSymbols = expectationKeys.concat(


### PR DESCRIPTION
#### Purpose 
This PR fixes lack of caching of `Object.getOwnPropertySymbols` in `deepEqualCyclic`, as caching standard library functions is advised in the below checklist for authors.

#### Background

I just tried updating my project from sinon 7.2.7 to sinon 7.3.0, a change that includes addition of the line that the PR changs, and I get a lot of errors like this :
```
'Unhandled promise rejection', TypeError: undefined is not a constructor (evaluating 'getOwnPropertySymbols(expectationObj)')
deepEqual@http://localhost:9876/absolute/Users/angelika/myproject/node_modules/sinon/pkg/sinon.js?911775df668393e499a0995e2789094c48727cc3:4395:40
deepEqualCyclic@http://localhost:9876/absolute/Users/angelika/myproject/node_modules/sinon/pkg/sinon.js?911775df668393e499a0995e2789094c48727cc3:4493:7
...
```
Such a situation could be caused in an environment that does not have symbol support, but it gets shimmed after Sinon is loaded (as pointed out to me here: https://github.com/sinonjs/samsam/pull/64#discussion_r268185148)

#### How to verify
1. Check out this branch
2. `npm install`
3. ?

I'm sorry, I don't know. 

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
