### PR TITLE
Fix #67: Add support for Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 site/
 coverage/
 dist/
+.nyc_output/

--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -7,6 +7,7 @@ var identical = require("./identical");
 var isArguments = require("./is-arguments");
 var isDate = require("./is-date");
 var isElement = require("./is-element");
+var isMap = require("./is-map");
 var isNaN = require("./is-nan");
 var isObject = require("./is-object");
 var isSet = require("./is-set");
@@ -150,6 +151,25 @@ function deepEqualCyclic(actual, expectation, match) {
             }
 
             return isSubset(actualObj, expectationObj, deepEqual);
+        }
+
+        if (isMap(actualObj) || isMap(expectationObj)) {
+            if (
+                !isMap(actualObj) ||
+                !isMap(expectationObj) ||
+                actualObj.size !== expectationObj.size
+            ) {
+                return false;
+            }
+
+            var mapsDeeplyEqual = true;
+            actualObj.forEach(function(value, key) {
+                mapsDeeplyEqual =
+                    mapsDeeplyEqual &&
+                    deepEqualCyclic(value, expectationObj.get(key));
+            });
+
+            return mapsDeeplyEqual;
         }
 
         return every.call(expectationKeysAndSymbols, function(key) {

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -635,6 +635,67 @@ describe("deepEqual", function() {
         });
     });
 
+    describe("when called with equal Map", function() {
+        before(function() {
+            if (typeof Map !== "function") {
+                this.skip();
+            }
+        });
+
+        it("should return false when other value is not a Map", function() {
+            var a = new Map();
+            var b = [];
+
+            assert.isFalse(samsam.deepEqual(a, b));
+            assert.isFalse(samsam.deepEqual(b, a));
+        });
+
+        it("should return false for different sized maps", function() {
+            var a = new Map();
+            var b = new Map();
+
+            a.set("a", "a");
+
+            assert.isFalse(samsam.deepEqual(a, b));
+        });
+
+        it("should return false for different custom properties", function() {
+            var a = new Map();
+            var b = new Map();
+
+            a.set("a", "a");
+            b.set("a", "a");
+
+            a.prop = 42;
+
+            assert.isFalse(samsam.deepEqual(a, b));
+        });
+
+        it("should return true for equal values", function() {
+            var a = new Map();
+            a.set(1, "a");
+            a.set(2, "b");
+
+            var b = new Map();
+            b.set(1, "a");
+            b.set(2, "b");
+
+            assert.isTrue(samsam.deepEqual(a, b));
+        });
+
+        it("should return false for unequal values", function() {
+            var a = new Map();
+            a.set(1, "a");
+            a.set(2, "b");
+
+            var b = new Map();
+            b.set(3, "c");
+            b.set(4, "d");
+
+            assert.isFalse(samsam.deepEqual(a, b));
+        });
+    });
+
     /**
      * Tests for cyclic objects.
      */

--- a/lib/is-map.js
+++ b/lib/is-map.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function isMap(value) {
+    return typeof Map !== "undefined" && value instanceof Map;
+}
+
+module.exports = isMap;


### PR DESCRIPTION
This PR fixes #67, where using deepEqual on non-equal `Map`  instances would return `true`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
