### PR TITLE
Improve tests using Sets with deepEqual

### DIFF
--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -575,6 +575,66 @@ describe("deepEqual", function() {
         });
     }
 
+    describe("when called with Set", function() {
+        before(function() {
+            if (typeof Set !== "function") {
+                this.skip();
+            }
+        });
+
+        it("should return `false` for different sized sets", function() {
+            var a = new Set();
+            var b = new Set();
+
+            a.add("a");
+
+            assert.isFalse(samsam.deepEqual(a, b));
+        });
+
+        it("should return `false` for different custom properties", function() {
+            var a = new Set();
+            var b = new Set();
+
+            a.add("a");
+            b.add("a");
+
+            a.prop = 42;
+
+            assert.isFalse(samsam.deepEqual(a, b));
+        });
+
+        it("should return `true` for equal sets", function() {
+            var VALUES = ["apple pie", "cherry pie", "key lime pie"];
+
+            var s1 = new Set();
+            var s2 = new Set();
+
+            VALUES.forEach(function(value) {
+                s1.add(value);
+                s2.add(value);
+            });
+
+            assert.isTrue(samsam.deepEqual(s1, s2));
+        });
+
+        it("should return `false` for un-equal sets", function() {
+            var VALUES = ["apple pie", "cherry pie", "key lime pie"];
+
+            var s1 = new Set();
+
+            VALUES.forEach(function(value) {
+                s1.add(value);
+            });
+
+            var s2 = new Set();
+            VALUES.slice(1).forEach(function(value) {
+                s2.add(value);
+            });
+
+            assert.isFalse(samsam.deepEqual(s1, s2));
+        });
+    });
+
     /**
      * Tests for cyclic objects.
      */


### PR DESCRIPTION
This PR adds tests discovered to be missing while working on #69.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
