### PR TITLE
Improve test coverage of createSet

### DIFF
--- a/lib/create-set.test.js
+++ b/lib/create-set.test.js
@@ -1,0 +1,45 @@
+"use strict";
+
+var assert = require("@sinonjs/referee").assert;
+var createSet = require("./create-set");
+
+describe("createSet", function() {
+    describe("when called without arguments", function() {
+        it("returns an empty Set", function() {
+            var set = createSet();
+
+            assert.isSet(set);
+            assert.equals(set.size, 0);
+        });
+    });
+
+    describe("when called with a non-empty Array", function() {
+        it("returns a Set with the same (distinct) members", function() {
+            var array = [0, 1, 1, 1, 1, 2, 3, 4];
+            var set = createSet(array);
+
+            set.forEach(function(value) {
+                assert.isTrue(array.includes(value));
+            });
+        });
+    });
+
+    describe("when called with non-Array or empty Array argument", function() {
+        it("throws a TypeError", function() {
+            var invalids = [
+                {},
+                new Date(),
+                new Set(),
+                new Map(),
+                null,
+                undefined
+            ];
+
+            invalids.forEach(function(value) {
+                assert.exception(function() {
+                    createSet(value);
+                }, /createSet can be called with either no arguments or an Array/);
+            });
+        });
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,19 +152,41 @@
         "type-detect": "4.0.8"
       }
     },
-    "@sinonjs/referee": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-2.0.0.tgz",
-      "integrity": "sha512-inOh34xub2/0diAWHrAZuakWe1NhtR2DkOXoS/3N7ooddxRZCxTH3TWyI4q7GatFGh+vmPCdWhws/1fziVdPhA==",
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
       "dev": true,
       "requires": {
-        "array.from": "^1.0.3",
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/referee": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-3.2.0.tgz",
+      "integrity": "sha512-t+sDpTvUmqgYWkPwTuO4gEivScbEKbF6eqFB9Cv70PqcyJla3w7Mj0JQyXn18uCDR2bIZglD4NNGeWGg8YfaGw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.0",
+        "array-from": "2.1.1",
         "bane": "^1.x",
-        "es6-promise": "^4.2.4",
         "lodash.includes": "^4.3.0",
         "lodash.isarguments": "^3.1.0",
-        "object-assign": "^4.1.1",
-        "samsam": "^1.x"
+        "object-assign": "^4.1.1"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
       }
     },
     "@types/acorn": {
@@ -459,16 +481,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
-    },
-    "array.from": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array.from/-/array.from-1.0.3.tgz",
-      "integrity": "sha1-y1hqrZIGfzQSKfQeDtZDKB26Vrc=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1"
-      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -7044,12 +7056,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "saucelabs": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@sinonjs/referee": "^2.0.0",
+    "@sinonjs/referee": "^3.2.0",
     "benchmark": "2.1.4",
     "eslint": "^6.2.0",
     "eslint-config-prettier": "^6.1.0",


### PR DESCRIPTION
This PR adds explicit tests of `createSet` to get it's coverage to 100%.

#### Purpose (TL;DR) - mandatory

Trying to get test coverage to 100%, so we can lock it there.

#### Solution  - optional

* Upgrade `@sinonjs/referee` to latest to get the `isSet` assertion
* Add tests

#### How to verify - mandatory

1. Check out this branch
1. `npm install`
1. Put a `.only` in the first `describe` in `create-set.test.js`
1. `npm run test-coverage`
1. Observe that the test coverage of `createSet` is 100%, when only its tests are run

```
-----------------------|----------|----------|----------|----------|-------------------|
File                   |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------------------|----------|----------|----------|----------|-------------------|
All files              |    31.78 |     4.78 |     8.41 |    31.78 |                   |
 create-set.js         |      100 |      100 |      100 |      100 |                   |
 deep-equal.js         |       26 |        0 |    16.67 |       26 |... 32,233,240,252 |
 get-class.js          |    66.67 |      100 |        0 |    66.67 |                 9 |
 identical.js          |       50 |        0 |        0 |       50 |          18,19,22 |
 is-arguments.js       |    15.38 |        0 |        0 |    15.38 |... 26,27,28,30,32 |
 is-date.js            |       50 |      100 |        0 |       50 |                 4 |
 is-element.js         |    22.22 |    28.57 |        0 |    22.22 |... 18,19,20,22,24 |
 is-map.js             |       50 |        0 |        0 |       50 |                 4 |
 is-nan.js             |    33.33 |        0 |        0 |    33.33 |               7,8 |
 is-neg-zero.js        |       50 |        0 |        0 |       50 |                10 |
 is-object.js          |       50 |        0 |        0 |       50 |                11 |
 is-set.js             |       50 |        0 |        0 |       50 |                 4 |
 is-subset.js          |       20 |        0 |        0 |       20 |... ,9,10,11,14,17 |
 iterable-to-string.js |    23.53 |        0 |        0 |    23.53 |... 33,34,37,38,41 |
 match.js              |    19.35 |        0 |    33.33 |    19.35 |... 19,123,126,129 |
 matcher.js            |    32.73 |     6.72 |     6.49 |    32.73 |... 47,454,455,458 |
 samsam.js             |      100 |      100 |      100 |      100 |                   |
-----------------------|----------|----------|----------|----------|-------------------|
```
#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
