### PR TITLE
Fix broken build in IE11

### DIFF
--- a/lib/create-set.test.js
+++ b/lib/create-set.test.js
@@ -19,7 +19,7 @@ describe("createSet", function() {
             var set = createSet(array);
 
             set.forEach(function(value) {
-                assert.isTrue(array.includes(value));
+                assert.isTrue(array.indexOf(value) !== -1);
             });
         });
     });


### PR DESCRIPTION
Don't use array.includes, it is not supported in IE11

#### How to verify - mandatory
1. Check out this branch
2. `npm run test-cloud`
3. Observe that the build doesn't fail in IE11

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
