### PR TITLE
Improve is-element.test.js

### DIFF
--- a/lib/is-element.test.js
+++ b/lib/is-element.test.js
@@ -22,29 +22,34 @@ describe("isElement", function() {
 
     it("returns true if DOM element node", function() {
         var element = document.createElement("div");
-        var checkElement = isElement(element);
-        assert.isTrue(checkElement);
+        var result = isElement(element);
+
+        assert.isTrue(result);
     });
 
     it("returns false if DOM text node", function() {
         var element = document.createTextNode("Hello");
-        var checkElement = isElement(element);
-        assert.isFalse(checkElement);
+        var result = isElement(element);
+
+        assert.isFalse(result);
     });
 
     it("returns false if node like object", function() {
         var nodeLike = { nodeType: 1 };
-        var checkElement = isElement(nodeLike);
-        assert.isFalse(checkElement);
+        var result = isElement(nodeLike);
+
+        assert.isFalse(result);
     });
 
     it("returns false if number", function() {
-        var checkElement = isElement(42);
-        assert.isFalse(checkElement);
+        var result = isElement(42);
+
+        assert.isFalse(result);
     });
 
     it("returns false if object", function() {
-        var checkElement = isElement({});
-        assert.isFalse(checkElement);
+        var result = isElement({});
+
+        assert.isFalse(result);
     });
 });

--- a/lib/is-element.test.js
+++ b/lib/is-element.test.js
@@ -1,35 +1,50 @@
 "use strict";
 
 var assert = require("@sinonjs/referee").assert;
-require("jsdom-global")();
-var samsam = require("./samsam");
+
+// in order for `is-element.js` to correctly detect the DOM being set up
+// in the previous line, we need to reload it, as other tests will have
+// loaded `is-element.js`, most likely without a DOM in place
+function requireWithDOM(file) {
+    require("jsdom-global")();
+
+    delete require.cache[require.resolve(file)];
+
+    return require("./is-element");
+}
 
 describe("isElement", function() {
+    var isElement;
+
+    before(function() {
+        isElement = requireWithDOM("./is-element");
+    });
+
     it("returns true if DOM element node", function() {
         var element = document.createElement("div");
-        var checkElement = samsam.isElement(element);
+        var checkElement = isElement(element);
         assert.isTrue(checkElement);
     });
 
     it("returns false if DOM text node", function() {
         var element = document.createTextNode("Hello");
-        var checkElement = samsam.isElement(element);
+        var checkElement = isElement(element);
         assert.isFalse(checkElement);
     });
 
     it("returns false if node like object", function() {
         var nodeLike = { nodeType: 1 };
-        var checkElement = samsam.isElement(nodeLike);
+        var checkElement = isElement(nodeLike);
         assert.isFalse(checkElement);
     });
 
     it("returns false if number", function() {
-        var checkElement = samsam.isElement(42);
+        var checkElement = isElement(42);
         assert.isFalse(checkElement);
     });
 
     it("returns false if object", function() {
-        var checkElement = samsam.isElement({});
+        var checkElement = isElement({});
         assert.isFalse(checkElement);
     });
 });

--- a/lib/is-element.test.js
+++ b/lib/is-element.test.js
@@ -20,36 +20,46 @@ describe("isElement", function() {
         isElement = requireWithDOM("./is-element");
     });
 
-    it("returns true if DOM element node", function() {
-        var element = document.createElement("div");
-        var result = isElement(element);
+    context("when called with a DOM element node", function() {
+        it("returns true", function() {
+            var element = document.createElement("div");
+            var result = isElement(element);
 
-        assert.isTrue(result);
+            assert.isTrue(result);
+        });
     });
 
-    it("returns false if DOM text node", function() {
-        var element = document.createTextNode("Hello");
-        var result = isElement(element);
+    context("when called with a DOM text node", function() {
+        it("returns false", function() {
+            var element = document.createTextNode("Hello");
+            var result = isElement(element);
 
-        assert.isFalse(result);
+            assert.isFalse(result);
+        });
     });
 
-    it("returns false if node like object", function() {
-        var nodeLike = { nodeType: 1 };
-        var result = isElement(nodeLike);
+    context("when called with a node like object", function() {
+        it("returns false", function() {
+            var nodeLike = { nodeType: 1 };
+            var result = isElement(nodeLike);
 
-        assert.isFalse(result);
+            assert.isFalse(result);
+        });
     });
 
-    it("returns false if number", function() {
-        var result = isElement(42);
+    context("when called with a number", function() {
+        it("returns false", function() {
+            var result = isElement(42);
 
-        assert.isFalse(result);
+            assert.isFalse(result);
+        });
     });
 
-    it("returns false if object", function() {
-        var result = isElement({});
+    context("when called with an object", function() {
+        it("returns false", function() {
+            var result = isElement({});
 
-        assert.isFalse(result);
+            assert.isFalse(result);
+        });
     });
 });


### PR DESCRIPTION
This PR makes a few improvements to `is-element.test.js`

#### Purpose (TL;DR)

Improve test isolation in order to allow future work to re-order tests.


#### Background

During work in #82 I discovered that this test is sensitive to load order.

#### Solution

* Increase test isolation be ensuring that `is-element.js` detects the DOM set up in the test harness.
* Also improve readability of the test file.

#### How to verify - mandatory

1. Observe all tests pass

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
