### PR TITLE
Refactor: iterableToString

### DIFF
--- a/lib/iterable-to-string.js
+++ b/lib/iterable-to-string.js
@@ -4,39 +4,40 @@ var slice = require("@sinonjs/commons").prototypes.string.slice;
 var typeOf = require("@sinonjs/commons").typeOf;
 var valueToString = require("@sinonjs/commons").valueToString;
 
-module.exports = function iterableToString(obj) {
-    var representation = "";
-
-    function stringify(item) {
-        return typeof item === "string"
-            ? "'" + item + "'"
-            : valueToString(item);
-    }
-
-    function mapToString(map) {
-        /* eslint-disable-next-line local-rules/no-prototype-methods */
-        map.forEach(function(value, key) {
-            representation +=
-                "[" + stringify(key) + "," + stringify(value) + "],";
-        });
-
-        representation = slice(representation, 0, -1);
-        return representation;
-    }
-
-    function genericIterableToString(iterable) {
-        /* eslint-disable-next-line local-rules/no-prototype-methods */
-        iterable.forEach(function(value) {
-            representation += stringify(value) + ",";
-        });
-
-        representation = slice(representation, 0, -1);
-        return representation;
-    }
-
+function iterableToString(obj) {
     if (typeOf(obj) === "map") {
         return mapToString(obj);
     }
 
     return genericIterableToString(obj);
-};
+}
+
+function mapToString(map) {
+    var representation = "";
+
+    /* eslint-disable-next-line local-rules/no-prototype-methods */
+    map.forEach(function(value, key) {
+        representation += "[" + stringify(key) + "," + stringify(value) + "],";
+    });
+
+    representation = slice(representation, 0, -1);
+    return representation;
+}
+
+function genericIterableToString(iterable) {
+    var representation = "";
+
+    /* eslint-disable-next-line local-rules/no-prototype-methods */
+    iterable.forEach(function(value) {
+        representation += stringify(value) + ",";
+    });
+
+    representation = slice(representation, 0, -1);
+    return representation;
+}
+
+function stringify(item) {
+    return typeof item === "string" ? "'" + item + "'" : valueToString(item);
+}
+
+module.exports = iterableToString;


### PR DESCRIPTION
* Reduce nesting of functions

This makes the code easier to reason about


#### How to verify - mandatory

1. Observe tests are still passing

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
