### PR TITLE
Replace coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # samsam
 
 [![Build status](https://secure.travis-ci.org/sinonjs/samsam.svg?branch=master)](http://travis-ci.org/sinonjs/samsam)
-[![Coverage Status](https://coveralls.io/repos/github/sinonjs/samsam/badge.svg?branch=master)](https://coveralls.io/github/sinonjs/samsam?branch=master)
-
+[![Coverage status](https://codecov.io/gh/sinonjs/samsam/branch/master/graph/badge.svg)](https://codecov.io/gh/sinonjs/samsam)
 Value identification and comparison functions
 
 Documentation: http://sinonjs.github.io/samsam/


### PR DESCRIPTION
Since ab993214b94d013072848902b26bb92cf8173e79 we have moved from
Coveralls to Codecov.

This updates the badge to point to Codecov.

#### How to verify - mandatory

1. View the `README.md`
2. Observe that the coverage badge points to Codecov
