### PR TITLE
Refactoring create-matcher

### DIFF
--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -11,6 +11,7 @@ var stringProto = require("@sinonjs/commons").prototypes.string;
 var typeOf = require("@sinonjs/commons").typeOf;
 var valueToString = require("@sinonjs/commons").valueToString;
 
+var assertMethodExists = require("./create-matcher/assert-method-exists");
 var assertType = require("./create-matcher/assert-type");
 
 var arrayIndexOf = arrayProto.indexOf;
@@ -40,24 +41,6 @@ var matcher = {
  */
 function isMatcher(object) {
     return isPrototypeOf(matcher, object);
-}
-
-/**
- * Throws a TypeError when expected method doesn't exist
- *
- * @private
- * @param {*} value A value to examine
- * @param {string} method The name of the method to look for
- * @param {name} name A name to use for the error message
- * @param {string} methodPath The name of the method to use for error messages
- * @throws {TypeError} When the method doesn't exist
- */
-function assertMethodExists(value, method, name, methodPath) {
-    if (value[method] === null || value[method] === undefined) {
-        throw new TypeError(
-            "Expected " + name + " to have method " + methodPath
-        );
-    }
 }
 
 /**

--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -14,6 +14,7 @@ var valueToString = require("@sinonjs/commons").valueToString;
 var assertMethodExists = require("./create-matcher/assert-method-exists");
 var assertType = require("./create-matcher/assert-type");
 var isIterable = require("./create-matcher/is-iterable");
+var isMatcher = require("./create-matcher/is-matcher");
 var matcherPrototype = require("./create-matcher/matcher-prototype");
 
 var arrayIndexOf = arrayProto.indexOf;
@@ -23,21 +24,9 @@ var map = arrayProto.map;
 var some = arrayProto.some;
 
 var hasOwnProperty = objectProto.hasOwnProperty;
-var isPrototypeOf = objectProto.isPrototypeOf;
 var objectToString = objectProto.toString;
 
 var stringIndexOf = stringProto.indexOf;
-
-/**
- * Returns `true` when `object` is a matcher
- *
- * @private
- * @param {*} object A value to examine
- * @returns {boolean} Returns `true` when `object` is a matcher
- */
-function isMatcher(object) {
-    return isPrototypeOf(matcherPrototype, object);
-}
 
 /**
  * Throws a TypeError when `value` is not a matcher

--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -11,6 +11,7 @@ var stringProto = require("@sinonjs/commons").prototypes.string;
 var typeOf = require("@sinonjs/commons").typeOf;
 var valueToString = require("@sinonjs/commons").valueToString;
 
+var assertMatcher = require("./create-matcher/assert-matcher");
 var assertMethodExists = require("./create-matcher/assert-method-exists");
 var assertType = require("./create-matcher/assert-type");
 var isIterable = require("./create-matcher/is-iterable");
@@ -27,18 +28,6 @@ var hasOwnProperty = objectProto.hasOwnProperty;
 var objectToString = objectProto.toString;
 
 var stringIndexOf = stringProto.indexOf;
-
-/**
- * Throws a TypeError when `value` is not a matcher
- *
- * @private
- * @param {*} value The value to examine
- */
-function assertMatcher(value) {
-    if (!isMatcher(value)) {
-        throw new TypeError("Matcher expected");
-    }
-}
 
 /**
  * Matches `actual` with `expectation`

--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -14,6 +14,7 @@ var valueToString = require("@sinonjs/commons").valueToString;
 var assertMethodExists = require("./create-matcher/assert-method-exists");
 var assertType = require("./create-matcher/assert-type");
 var isIterable = require("./create-matcher/is-iterable");
+var matcherPrototype = require("./create-matcher/matcher-prototype");
 
 var arrayIndexOf = arrayProto.indexOf;
 var arrayEvery = arrayProto.every;
@@ -27,12 +28,6 @@ var objectToString = objectProto.toString;
 
 var stringIndexOf = stringProto.indexOf;
 
-var matcher = {
-    toString: function() {
-        return this.message;
-    }
-};
-
 /**
  * Returns `true` when `object` is a matcher
  *
@@ -41,7 +36,7 @@ var matcher = {
  * @returns {boolean} Returns `true` when `object` is a matcher
  */
 function isMatcher(object) {
-    return isPrototypeOf(matcher, object);
+    return isPrototypeOf(matcherPrototype, object);
 }
 
 /**
@@ -147,7 +142,7 @@ var TYPE_MAP = {
  * @returns {object} A matcher object
  */
 function createMatcher(expectation, message) {
-    var m = Object.create(matcher);
+    var m = Object.create(matcherPrototype);
     var type = typeOf(expectation);
 
     if (message !== undefined && typeof message !== "string") {
@@ -174,40 +169,6 @@ function createMatcher(expectation, message) {
 
     return m;
 }
-
-matcher.or = function(valueOrMatcher) {
-    if (!arguments.length) {
-        throw new TypeError("Matcher expected");
-    }
-
-    var m2 = isMatcher(valueOrMatcher)
-        ? valueOrMatcher
-        : createMatcher(valueOrMatcher);
-    var m1 = this;
-    var or = Object.create(matcher);
-    or.test = function(actual) {
-        return m1.test(actual) || m2.test(actual);
-    };
-    or.message = m1.message + ".or(" + m2.message + ")";
-    return or;
-};
-
-matcher.and = function(valueOrMatcher) {
-    if (!arguments.length) {
-        throw new TypeError("Matcher expected");
-    }
-
-    var m2 = isMatcher(valueOrMatcher)
-        ? valueOrMatcher
-        : createMatcher(valueOrMatcher);
-    var m1 = this;
-    var and = Object.create(matcher);
-    and.test = function(actual) {
-        return m1.test(actual) && m2.test(actual);
-    };
-    and.message = m1.message + ".and(" + m2.message + ")";
-    return and;
-};
 
 createMatcher.isMatcher = isMatcher;
 

--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -11,6 +11,8 @@ var stringProto = require("@sinonjs/commons").prototypes.string;
 var typeOf = require("@sinonjs/commons").typeOf;
 var valueToString = require("@sinonjs/commons").valueToString;
 
+var assertType = require("./create-matcher/assert-type");
+
 var arrayIndexOf = arrayProto.indexOf;
 var arrayEvery = arrayProto.every;
 var join = arrayProto.join;
@@ -38,30 +40,6 @@ var matcher = {
  */
 function isMatcher(object) {
     return isPrototypeOf(matcher, object);
-}
-
-/**
- * Ensures that value is of type
- *
- * @private
- * @param {*} value A value to examine
- * @param {string} type A basic JavaScript type to compare to, e.g. "object", "string"
- * @param {string} name A string to use for the error message
- * @throws {TypeError} If value is not of the expected type
- * @returns {undefined}
- */
-function assertType(value, type, name) {
-    var actual = typeOf(value);
-    if (actual !== type) {
-        throw new TypeError(
-            "Expected type of " +
-                name +
-                " to be " +
-                type +
-                ", but was " +
-                actual
-        );
-    }
 }
 
 /**

--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -16,10 +16,10 @@ var assertMethodExists = require("./create-matcher/assert-method-exists");
 var assertType = require("./create-matcher/assert-type");
 var isIterable = require("./create-matcher/is-iterable");
 var isMatcher = require("./create-matcher/is-matcher");
+var matchObject = require("./create-matcher/match-object");
 var matcherPrototype = require("./create-matcher/matcher-prototype");
 
 var arrayIndexOf = arrayProto.indexOf;
-var arrayEvery = arrayProto.every;
 var join = arrayProto.join;
 var map = arrayProto.map;
 var some = arrayProto.some;
@@ -28,39 +28,6 @@ var hasOwnProperty = objectProto.hasOwnProperty;
 var objectToString = objectProto.toString;
 
 var stringIndexOf = stringProto.indexOf;
-
-/**
- * Matches `actual` with `expectation`
- *
- * @private
- * @param {*} actual A value to examine
- * @param {object} expectation An object with properties to match on
- * @returns {boolean} Returns true when `actual` matches all properties in `expectation`
- */
-function matchObject(actual, expectation) {
-    if (actual === null || actual === undefined) {
-        return false;
-    }
-
-    return arrayEvery(Object.keys(expectation), function(key) {
-        var exp = expectation[key];
-        var act = actual[key];
-
-        if (isMatcher(exp)) {
-            if (!exp.test(act)) {
-                return false;
-            }
-        } else if (typeOf(exp) === "object") {
-            if (!matchObject(act, exp)) {
-                return false;
-            }
-        } else if (!deepEqual(act, exp)) {
-            return false;
-        }
-
-        return true;
-    });
-}
 
 var TYPE_MAP = {
     function: function(m, expectation, message) {

--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -13,6 +13,7 @@ var valueToString = require("@sinonjs/commons").valueToString;
 
 var assertMethodExists = require("./create-matcher/assert-method-exists");
 var assertType = require("./create-matcher/assert-type");
+var isIterable = require("./create-matcher/is-iterable");
 
 var arrayIndexOf = arrayProto.indexOf;
 var arrayEvery = arrayProto.every;
@@ -53,17 +54,6 @@ function assertMatcher(value) {
     if (!isMatcher(value)) {
         throw new TypeError("Matcher expected");
     }
-}
-
-/**
- * Returns `true` for iterables
- *
- * @private
- * @param {*} value A value to examine
- * @returns {boolean} Returns `true` when `value` looks like an iterable
- */
-function isIterable(value) {
-    return Boolean(value) && typeOf(value.forEach) === "function";
 }
 
 /**

--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -7,7 +7,6 @@ var functionName = require("@sinonjs/commons").functionName;
 var get = require("lodash").get;
 var iterableToString = require("./iterable-to-string");
 var objectProto = require("@sinonjs/commons").prototypes.object;
-var stringProto = require("@sinonjs/commons").prototypes.string;
 var typeOf = require("@sinonjs/commons").typeOf;
 var valueToString = require("@sinonjs/commons").valueToString;
 
@@ -16,67 +15,16 @@ var assertMethodExists = require("./create-matcher/assert-method-exists");
 var assertType = require("./create-matcher/assert-type");
 var isIterable = require("./create-matcher/is-iterable");
 var isMatcher = require("./create-matcher/is-matcher");
-var matchObject = require("./create-matcher/match-object");
+
 var matcherPrototype = require("./create-matcher/matcher-prototype");
 
 var arrayIndexOf = arrayProto.indexOf;
-var join = arrayProto.join;
-var map = arrayProto.map;
 var some = arrayProto.some;
 
 var hasOwnProperty = objectProto.hasOwnProperty;
 var objectToString = objectProto.toString;
 
-var stringIndexOf = stringProto.indexOf;
-
-var TYPE_MAP = {
-    function: function(m, expectation, message) {
-        m.test = expectation;
-        m.message = message || "match(" + functionName(expectation) + ")";
-    },
-    number: function(m, expectation) {
-        m.test = function(actual) {
-            // we need type coercion here
-            return expectation == actual; // eslint-disable-line eqeqeq
-        };
-    },
-    object: function(m, expectation) {
-        var array = [];
-
-        if (typeof expectation.test === "function") {
-            m.test = function(actual) {
-                return expectation.test(actual) === true;
-            };
-            m.message = "match(" + functionName(expectation.test) + ")";
-            return m;
-        }
-
-        array = map(Object.keys(expectation), function(key) {
-            return key + ": " + valueToString(expectation[key]);
-        });
-
-        m.test = function(actual) {
-            return matchObject(actual, expectation);
-        };
-        m.message = "match(" + join(array, ", ") + ")";
-
-        return m;
-    },
-    regexp: function(m, expectation) {
-        m.test = function(actual) {
-            return typeof actual === "string" && expectation.test(actual);
-        };
-    },
-    string: function(m, expectation) {
-        m.test = function(actual) {
-            return (
-                typeof actual === "string" &&
-                stringIndexOf(actual, expectation) !== -1
-            );
-        };
-        m.message = 'match("' + expectation + '")';
-    }
-};
+var TYPE_MAP = require("./create-matcher/type-map");
 
 /**
  * Creates a matcher object for the passed expectation

--- a/lib/create-matcher/assert-matcher.js
+++ b/lib/create-matcher/assert-matcher.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var isMatcher = require("./is-matcher");
+
+/**
+ * Throws a TypeError when `value` is not a matcher
+ *
+ * @private
+ * @param {*} value The value to examine
+ */
+function assertMatcher(value) {
+    if (!isMatcher(value)) {
+        throw new TypeError("Matcher expected");
+    }
+}
+
+module.exports = assertMatcher;

--- a/lib/create-matcher/assert-method-exists.js
+++ b/lib/create-matcher/assert-method-exists.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/**
+ * Throws a TypeError when expected method doesn't exist
+ *
+ * @private
+ * @param {*} value A value to examine
+ * @param {string} method The name of the method to look for
+ * @param {name} name A name to use for the error message
+ * @param {string} methodPath The name of the method to use for error messages
+ * @throws {TypeError} When the method doesn't exist
+ */
+function assertMethodExists(value, method, name, methodPath) {
+    if (value[method] === null || value[method] === undefined) {
+        throw new TypeError(
+            "Expected " + name + " to have method " + methodPath
+        );
+    }
+}
+
+module.exports = assertMethodExists;

--- a/lib/create-matcher/assert-type.js
+++ b/lib/create-matcher/assert-type.js
@@ -1,0 +1,29 @@
+"use strict";
+
+var typeOf = require("@sinonjs/commons").typeOf;
+
+/**
+ * Ensures that value is of type
+ *
+ * @private
+ * @param {*} value A value to examine
+ * @param {string} type A basic JavaScript type to compare to, e.g. "object", "string"
+ * @param {string} name A string to use for the error message
+ * @throws {TypeError} If value is not of the expected type
+ * @returns {undefined}
+ */
+function assertType(value, type, name) {
+    var actual = typeOf(value);
+    if (actual !== type) {
+        throw new TypeError(
+            "Expected type of " +
+                name +
+                " to be " +
+                type +
+                ", but was " +
+                actual
+        );
+    }
+}
+
+module.exports = assertType;

--- a/lib/create-matcher/is-iterable.js
+++ b/lib/create-matcher/is-iterable.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var typeOf = require("@sinonjs/commons").typeOf;
+
+/**
+ * Returns `true` for iterables
+ *
+ * @private
+ * @param {*} value A value to examine
+ * @returns {boolean} Returns `true` when `value` looks like an iterable
+ */
+function isIterable(value) {
+    return Boolean(value) && typeOf(value.forEach) === "function";
+}
+
+module.exports = isIterable;

--- a/lib/create-matcher/is-matcher.js
+++ b/lib/create-matcher/is-matcher.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var isPrototypeOf = require("@sinonjs/commons").prototypes.object.isPrototypeOf;
+
+var matcherPrototype = require("./matcher-prototype");
+
+/**
+ * Returns `true` when `object` is a matcher
+ *
+ * @private
+ * @param {*} object A value to examine
+ * @returns {boolean} Returns `true` when `object` is a matcher
+ */
+function isMatcher(object) {
+    return isPrototypeOf(matcherPrototype, object);
+}
+
+module.exports = isMatcher;

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var every = require("@sinonjs/commons").prototypes.array.every;
+var typeOf = require("@sinonjs/commons").typeOf;
+
+var deepEqual = require("../deep-equal");
+
+var isMatcher = require("./is-matcher");
+/**
+ * Matches `actual` with `expectation`
+ *
+ * @private
+ * @param {*} actual A value to examine
+ * @param {object} expectation An object with properties to match on
+ * @returns {boolean} Returns true when `actual` matches all properties in `expectation`
+ */
+function matchObject(actual, expectation) {
+    if (actual === null || actual === undefined) {
+        return false;
+    }
+
+    return every(Object.keys(expectation), function(key) {
+        var exp = expectation[key];
+        var act = actual[key];
+
+        if (isMatcher(exp)) {
+            if (!exp.test(act)) {
+                return false;
+            }
+        } else if (typeOf(exp) === "object") {
+            if (!matchObject(act, exp)) {
+                return false;
+            }
+        } else if (!deepEqual(act, exp)) {
+            return false;
+        }
+
+        return true;
+    });
+}
+
+module.exports = matchObject;

--- a/lib/create-matcher/matcher-prototype.js
+++ b/lib/create-matcher/matcher-prototype.js
@@ -1,0 +1,49 @@
+"use strict";
+
+var matcherPrototype = {
+    toString: function() {
+        return this.message;
+    }
+};
+
+matcherPrototype.or = function(valueOrMatcher) {
+    var createMatcher = require("../create-matcher");
+    var isMatcher = createMatcher.isMatcher;
+
+    if (!arguments.length) {
+        throw new TypeError("Matcher expected");
+    }
+
+    var m2 = isMatcher(valueOrMatcher)
+        ? valueOrMatcher
+        : createMatcher(valueOrMatcher);
+    var m1 = this;
+    var or = Object.create(matcherPrototype);
+    or.test = function(actual) {
+        return m1.test(actual) || m2.test(actual);
+    };
+    or.message = m1.message + ".or(" + m2.message + ")";
+    return or;
+};
+
+matcherPrototype.and = function(valueOrMatcher) {
+    var createMatcher = require("../create-matcher");
+    var isMatcher = createMatcher.isMatcher;
+
+    if (!arguments.length) {
+        throw new TypeError("Matcher expected");
+    }
+
+    var m2 = isMatcher(valueOrMatcher)
+        ? valueOrMatcher
+        : createMatcher(valueOrMatcher);
+    var m1 = this;
+    var and = Object.create(matcherPrototype);
+    and.test = function(actual) {
+        return m1.test(actual) && m2.test(actual);
+    };
+    and.message = m1.message + ".and(" + m2.message + ")";
+    return and;
+};
+
+module.exports = matcherPrototype;

--- a/lib/create-matcher/type-map.js
+++ b/lib/create-matcher/type-map.js
@@ -1,0 +1,60 @@
+"use strict";
+
+var functionName = require("@sinonjs/commons").functionName;
+var join = require("@sinonjs/commons").prototypes.array.join;
+var map = require("@sinonjs/commons").prototypes.array.map;
+var stringIndexOf = require("@sinonjs/commons").prototypes.string.indexOf;
+var valueToString = require("@sinonjs/commons").valueToString;
+
+var matchObject = require("./match-object");
+
+var TYPE_MAP = {
+    function: function(m, expectation, message) {
+        m.test = expectation;
+        m.message = message || "match(" + functionName(expectation) + ")";
+    },
+    number: function(m, expectation) {
+        m.test = function(actual) {
+            // we need type coercion here
+            return expectation == actual; // eslint-disable-line eqeqeq
+        };
+    },
+    object: function(m, expectation) {
+        var array = [];
+
+        if (typeof expectation.test === "function") {
+            m.test = function(actual) {
+                return expectation.test(actual) === true;
+            };
+            m.message = "match(" + functionName(expectation.test) + ")";
+            return m;
+        }
+
+        array = map(Object.keys(expectation), function(key) {
+            return key + ": " + valueToString(expectation[key]);
+        });
+
+        m.test = function(actual) {
+            return matchObject(actual, expectation);
+        };
+        m.message = "match(" + join(array, ", ") + ")";
+
+        return m;
+    },
+    regexp: function(m, expectation) {
+        m.test = function(actual) {
+            return typeof actual === "string" && expectation.test(actual);
+        };
+    },
+    string: function(m, expectation) {
+        m.test = function(actual) {
+            return (
+                typeof actual === "string" &&
+                stringIndexOf(actual, expectation) !== -1
+            );
+        };
+        m.message = 'match("' + expectation + '")';
+    }
+};
+
+module.exports = TYPE_MAP;


### PR DESCRIPTION
This PR is a partial refactoring of `create-matcher.js`.

#### Purpose (TL;DR) - mandatory

In order to make the code easier to understand and test, we need to split it up into manageable chunks.





#### Background

As can be seen in the diagram below, there are a lot of dependencies between the different parts. Most interesting is the circular dependency between `matcher-prototype` and `create-matcher.

I've overcome that problem by only using `require("../create-matcher")` inside the functions of `matcher-prototype` instead of at the top of the file.

```
                              ┌───────────────────┐   
                              │ matcher-prototype │◀━┓
                              └───────────────────┘  ┃
                                        ▲            ┃
                                        │            ┃
                                        │            ┃
┌───────────────────┐         ┌───────────────────┐  ┃
│  assert-matcher   │────────▶│    is-matcher     │  ┃
└───────────────────┘         └───────────────────┘  ┃
                                        ▲            ┃
                                        │            ┃
                                        │            ┃
┌───────────────────┐         ┌───────────────────┐  ┃
│    deep-equal     │◀────────│   match-object    │  ┃
└───────────────────┘         └───────────────────┘  ┃
          ▲                             ▲            ┃
          │                             │            ┃
          │                             │            ┃
          │                   ┌───────────────────┐  ┃
          │                   │     type-map      │  ┃
          │                   └───────────────────┘  ┃
          │                             ▲            ┃
          │                             │            ┃
          │                             │            ┃
          │                   ┌───────────────────┐  ┃
          └───────────────────│  create-matcher   │◀━┛
                              └───────────────────┘   
```

#### Solution  - optional

Extract parts into separate files.

There's still a while to go until `createMatcher` can be considered well factored, I will pick that up another day.

#### How to verify - mandatory

1. Check out this branch
1. `npm run test-cloud`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
