### PR TITLE
add support for BigInt

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -11,6 +11,7 @@ globals:
   Map: false
   Set: false
   Symbol: false
+  BigInt: false
 
 plugins:
   - ie11

--- a/lib/match.js
+++ b/lib/match.js
@@ -79,6 +79,10 @@ function match(object, matcherOrValue) {
         return matcherOrValue === object;
     }
 
+    if (typeof matcherOrValue === "bigint") {
+        return matcherOrValue === object;
+    }
+
     if (typeof matcherOrValue === "undefined") {
         return typeof object === "undefined";
     }

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -515,4 +515,24 @@ describe("match", function() {
             assert.isFalse(samsam.match(createSet([1, 2, 3]), 123));
         });
     }
+
+    describe("BigInt", function() {
+        before(function() {
+            if (typeof BigInt === "undefined") {
+                this.skip();
+            }
+        });
+
+        it("returns true if comparing the same value", function() {
+            assert.isTrue(samsam.match(BigInt(1), BigInt(1)));
+        });
+
+        it("returns false if comparing different values", function() {
+            assert.isFalse(samsam.match(BigInt(1), BigInt(-1)));
+        });
+
+        it("returns false if comparing BigInt with a value of another type", function() {
+            assert.isFalse(samsam.match(BigInt(1), 1));
+        });
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This PR adds Support for [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)


#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
