### PR TITLE
add support for comparing symbols

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -87,6 +87,10 @@ function match(object, matcherOrValue) {
         return typeof object === "undefined";
     }
 
+    if (typeof matcherOrValue === "symbol") {
+        return matcherOrValue === object;
+    }
+
     if (matcherOrValue === null) {
         return object === null;
     }

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -535,4 +535,29 @@ describe("match", function() {
             assert.isFalse(samsam.match(BigInt(1), 1));
         });
     });
+
+    describe("symbol", function() {
+        before(function() {
+            if (typeof Symbol === "undefined") {
+                this.skip();
+            }
+        });
+
+        it("returns true if comparing the same symbol", function() {
+            var symbol = Symbol("foo");
+            var checkMatch = samsam.match(symbol, symbol);
+            assert.isTrue(checkMatch);
+        });
+
+        it("returns false if comparing two differnt symbols", function() {
+            var checkMatch = samsam.match(Symbol("foo"), Symbol("bar"));
+            assert.isFalse(checkMatch);
+        });
+
+        it("returns false if two symbols with the same value", function() {
+            var value = "foo";
+            var checkMatch = samsam.match(Symbol(value), Symbol(value));
+            assert.isFalse(checkMatch);
+        });
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Support comparing [`Symbol`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) in `samsam`.

Discussion: #112 

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
