### PR TITLE
Deep equal coverage

### DIFF
--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -2,6 +2,7 @@
 
 var valueToString = require("@sinonjs/commons").valueToString;
 var className = require("@sinonjs/commons").className;
+var typeOf = require("@sinonjs/commons").typeOf;
 var arrayProto = require("@sinonjs/commons").prototypes.array;
 var objectProto = require("@sinonjs/commons").prototypes.object;
 var mapForEach = require("@sinonjs/commons").prototypes.map.forEach;
@@ -127,7 +128,7 @@ function deepEqualCyclic(actual, expectation, match) {
         var actualName = className(actualObj);
         var expectationName = className(expectationObj);
         var expectationSymbols =
-            typeof getOwnPropertySymbols === "function"
+            typeOf(getOwnPropertySymbols) === "function"
                 ? getOwnPropertySymbols(expectationObj)
                 : [];
         var expectationKeysAndSymbols = concat(

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -3,6 +3,7 @@
 var assert = require("@sinonjs/referee").assert;
 var createSet = require("./create-set");
 var createMatcher = require("./create-matcher");
+var proxyquire = require("proxyquire");
 
 var samsam = require("./samsam");
 
@@ -427,6 +428,23 @@ describe("deepEqual", function() {
             obj1[symbol] = 42;
             var checkDeep = samsam.deepEqual(obj1, obj2);
             assert.isTrue(checkDeep);
+        });
+
+        describe("without symbol support", function() {
+            it("returns true if object missing expected symbolic properties", function() {
+                var deepEqual = proxyquire("./deep-equal", {
+                    "@sinonjs/commons": {
+                        typeOf: function() {
+                            return "undefined";
+                        }
+                    }
+                });
+                var obj1 = {};
+                var obj2 = {};
+                obj2[symbol] = 42;
+
+                assert.isTrue(deepEqual(obj1, obj2));
+            });
         });
     });
 

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -4,7 +4,6 @@ var assert = require("@sinonjs/referee").assert;
 var createSet = require("./create-set");
 var createMatcher = require("./create-matcher");
 
-require("jsdom-global")();
 var samsam = require("./samsam");
 
 /**
@@ -540,12 +539,6 @@ describe("deepEqual", function() {
         assert.isTrue(samsam.deepEqual(error, error));
     });
 
-    it("passes same DOM elements", function() {
-        var element = document.createElement("div");
-
-        assert.isTrue(samsam.deepEqual(element, element));
-    });
-
     it("return false if empty object to empty instance", function() {
         // Because eslint-config-sinon disables es6, we can't
         // use a class definition here
@@ -556,27 +549,54 @@ describe("deepEqual", function() {
         assert.isFalse(samsam.deepEqual(obj, instance));
     });
 
-    it("fails different DOM elements", function() {
-        var element = document.createElement("div");
-        var el = document.createElement("div");
-
-        assert.isFalse(samsam.deepEqual(element, el));
-    });
-
-    it("does not modify DOM elements when comparing them", function() {
-        var el = document.createElement("div");
-        document.body.appendChild(el);
-        samsam.deepEqual(el, {});
-
-        assert.same(el.parentNode, document.body);
-        assert.equals(el.childNodes.length, 0);
-    });
-
     it("fails unequal errors", function() {
         var error1 = new Error();
         var error2 = new Error();
 
         assert.isFalse(samsam.deepEqual(error1, error2));
+    });
+
+    describe("DOM", function() {
+        before(function() {
+            if (typeof document !== "undefined") {
+                this.samsam = samsam;
+                return;
+            }
+            this.jsdom = require("jsdom-global")();
+            // Reload all files to properly apply jsdom
+            delete require.cache[require.resolve("./is-element")];
+            delete require.cache[require.resolve("./deep-equal")];
+            delete require.cache[require.resolve("./samsam")];
+            this.samsam = require("./samsam");
+        });
+
+        after(function() {
+            if (this.jsdom) {
+                this.jsdom();
+            }
+        });
+
+        it("passes same DOM elements", function() {
+            var element = document.createElement("div");
+
+            assert.isTrue(this.samsam.deepEqual(element, element));
+        });
+
+        it("fails different DOM elements", function() {
+            var element = document.createElement("div");
+            var el = document.createElement("div");
+
+            assert.isFalse(this.samsam.deepEqual(element, el));
+        });
+
+        it("does not modify DOM elements when comparing them", function() {
+            var el = document.createElement("div");
+            document.body.appendChild(el);
+            this.samsam.deepEqual(el, {});
+
+            assert.same(el.parentNode, document.body);
+            assert.equals(el.childNodes.length, 0);
+        });
     });
 
     if (typeof Set !== "undefined") {

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -589,6 +589,7 @@ describe("deepEqual", function() {
         });
 
         after(function() {
+            delete this.samsam;
             if (this.jsdom) {
                 this.jsdom();
             }


### PR DESCRIPTION
#### Purpose

This PR increases coverage for `deepEqual` to 💯 

#### Background (Problem in detail)

The coverage could not be reached because `jsdom` was not properly applied in `deep-equal.test.js` and therefore [`isElement`](https://github.com/sinonjs/samsam/blob/master/lib/deep-equal.js#L97) always returned `false`. Now there is a dedicated Test suite that applies `jsdom` and reloads all files.


#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run test`, `npm run test-coverage`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
