### PR TITLE
Ignore impossible else path

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -119,6 +119,7 @@ function match(object, matcherOrValue) {
         return isDate(object) && object.getTime() === matcherOrValue.getTime();
     }
 
+    /* istanbul ignore else */
     if (matcherOrValue && typeof matcherOrValue === "object") {
         if (matcherOrValue === object) {
             return true;


### PR DESCRIPTION
The else path is a fallback for when we've managed somehow to find the impossible combination of arguments to make this pass, despite the input validation

Not sure it is even possible to get to the else path

#### How to verify - mandatory
1. Check out this branch
1. `npm ci`
1. `npm run test-coverage`
1. Observe coverage reported as 100% for statements, branches, functions and lines
