### PR TITLE
Avoid test failures in IE11

### DIFF
--- a/lib/samsam.test.js
+++ b/lib/samsam.test.js
@@ -4,7 +4,20 @@ var assert = require("@sinonjs/referee").assert;
 
 var samsam = require("./samsam");
 
+var engineSupportsFunctionNameProperty = (function detectFunctionNameSupport() {
+    return (
+        typeof detectFunctionNameSupport.name === "string" &&
+        detectFunctionNameSupport.name === "detectFunctionNameSupport"
+    );
+})();
+
 describe("samsam API", function() {
+    before(function() {
+        if (!engineSupportsFunctionNameProperty) {
+            this.skip();
+        }
+    });
+
     it("should have a binary method named `createMatcher`", function() {
         assert.equals(samsam.createMatcher.name, "createMatcher");
         assert.hasArity(samsam.createMatcher, 2);


### PR DESCRIPTION
When the runtime doesn't support the `.name` property on `Functions`,
skip the API tests.



#### Purpose

Make tests pass in IE11

#### Background

When running tests in IE11, I was seeing these failures:

```
8) samsam API
       should have a binary method named `createMatcher`:
     AssertionError: [assert.equals] undefined expected to be equal to createMatcher
      at fail (node_modules/@sinonjs/referee/lib/create-fail.js:15)
      at ctx.fail (node_modules/@sinonjs/referee/lib/define-assertion.js:46)
      at assertion (node_modules/@sinonjs/referee/lib/define-assertion.js:68)
      at referee[type][name] (node_modules/@sinonjs/referee/lib/define-assertion.js:93)
      at Anonymous function (lib/samsam.test.js:9)

  9) samsam API
       should have a binary method named `deepEqual`:
     AssertionError: [assert.equals] undefined expected to be equal to deepEqual
      at fail (node_modules/@sinonjs/referee/lib/create-fail.js:15)
      at ctx.fail (node_modules/@sinonjs/referee/lib/define-assertion.js:46)
      at assertion (node_modules/@sinonjs/referee/lib/define-assertion.js:68)
      at referee[type][name] (node_modules/@sinonjs/referee/lib/define-assertion.js:93)
      at Anonymous function (lib/samsam.test.js:14)

  10) samsam API
       should have a binary method named `identical`:
     AssertionError: [assert.equals] undefined expected to be equal to identical
      at fail (node_modules/@sinonjs/referee/lib/create-fail.js:15)
      at ctx.fail (node_modules/@sinonjs/referee/lib/define-assertion.js:46)
      at assertion (node_modules/@sinonjs/referee/lib/define-assertion.js:68)
      at referee[type][name] (node_modules/@sinonjs/referee/lib/define-assertion.js:93)
      at Anonymous function (lib/samsam.test.js:19)

  11) samsam API
       should have a unary method named `isArguments`:
     AssertionError: [assert.equals] undefined expected to be equal to isArguments
      at fail (node_modules/@sinonjs/referee/lib/create-fail.js:15)
      at ctx.fail (node_modules/@sinonjs/referee/lib/define-assertion.js:46)
      at assertion (node_modules/@sinonjs/referee/lib/define-assertion.js:68)
      at referee[type][name] (node_modules/@sinonjs/referee/lib/define-assertion.js:93)
      at Anonymous function (lib/samsam.test.js:24)

  12) samsam API
       should have a unary method named `isElement`:
     AssertionError: [assert.equals] undefined expected to be equal to isElement
      at fail (node_modules/@sinonjs/referee/lib/create-fail.js:15)
      at ctx.fail (node_modules/@sinonjs/referee/lib/define-assertion.js:46)
      at assertion (node_modules/@sinonjs/referee/lib/define-assertion.js:68)
      at referee[type][name] (node_modules/@sinonjs/referee/lib/define-assertion.js:93)
      at Anonymous function (lib/samsam.test.js:29)

  13) samsam API
       should have a unary method named `isMap`:
     AssertionError: [assert.equals] undefined expected to be equal to isMap
      at fail (node_modules/@sinonjs/referee/lib/create-fail.js:15)
      at ctx.fail (node_modules/@sinonjs/referee/lib/define-assertion.js:46)
      at assertion (node_modules/@sinonjs/referee/lib/define-assertion.js:68)
      at referee[type][name] (node_modules/@sinonjs/referee/lib/define-assertion.js:93)
      at Anonymous function (lib/samsam.test.js:34)

  14) samsam API
       should have a unary method named `isNegZero`:
     AssertionError: [assert.equals] undefined expected to be equal to isNegZero
      at fail (node_modules/@sinonjs/referee/lib/create-fail.js:15)
      at ctx.fail (node_modules/@sinonjs/referee/lib/define-assertion.js:46)
      at assertion (node_modules/@sinonjs/referee/lib/define-assertion.js:68)
      at referee[type][name] (node_modules/@sinonjs/referee/lib/define-assertion.js:93)
      at Anonymous function (lib/samsam.test.js:39)

  15) samsam API
       should have a unary method named `isSet`:
     AssertionError: [assert.equals] undefined expected to be equal to isSet
      at fail (node_modules/@sinonjs/referee/lib/create-fail.js:15)
      at ctx.fail (node_modules/@sinonjs/referee/lib/define-assertion.js:46)
      at assertion (node_modules/@sinonjs/referee/lib/define-assertion.js:68)
      at referee[type][name] (node_modules/@sinonjs/referee/lib/define-assertion.js:93)
      at Anonymous function (lib/samsam.test.js:44)

  16) samsam API
       should have a binary method named `match`:
     AssertionError: [assert.equals] undefined expected to be equal to match
      at fail (node_modules/@sinonjs/referee/lib/create-fail.js:15)
      at ctx.fail (node_modules/@sinonjs/referee/lib/define-assertion.js:46)
      at assertion (node_modules/@sinonjs/referee/lib/define-assertion.js:68)
      at referee[type][name] (node_modules/@sinonjs/referee/lib/define-assertion.js:93)
      at Anonymous function (lib/samsam.test.js:49)
```

Using `git bisect` I was able to determine that the failing tests were introduced in ef1272d2d3c073a0ba56d9f66c468553033aefcd.

#### Solution

* Detect support for `.name` property on `Function` before trying to run those tests.

#### How to verify - mandatory

1. Check out this branch
1. `npm ci`
1. `npm run test-cloud`
1. Observe there are no errors reported for "samsam API" (I'll fix the other errors in other PRs).
