### PR TITLE
Throw on matching Map in unsupporting engines

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -4,6 +4,7 @@ var valueToString = require("@sinonjs/commons").valueToString;
 var indexOf = require("@sinonjs/commons").prototypes.string.indexOf;
 var forEach = require("@sinonjs/commons").prototypes.array.forEach;
 
+var engineCanCompareMaps = typeof Array.from === "function";
 var deepEqual = require("./deep-equal").use(match); // eslint-disable-line no-use-before-define
 var getClass = require("./get-class");
 var isDate = require("./is-date");
@@ -105,6 +106,14 @@ function match(object, matcherOrValue) {
     }
 
     if (isMap(object)) {
+        // this is covered by a test, that is only run in IE, but we collect coverage information in node
+        /* istanbul ignore next */
+        if (!engineCanCompareMaps) {
+            throw new Error(
+                "The JavaScript engine does not support Array.from and cannot reliably do value comparison of Map instances"
+            );
+        }
+
         return (
             isMap(matcherOrValue) &&
             arrayContains(Array.from(object), Array.from(matcherOrValue), match)

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -1,7 +1,9 @@
 "use strict";
 
 var assert = require("@sinonjs/referee").assert;
+
 var createSet = require("./create-set");
+var engineCanCompareMaps = typeof Array.from === "function";
 var samsam = require("./samsam");
 
 describe("match", function() {
@@ -517,81 +519,109 @@ describe("match", function() {
     }
 
     describe("Map", function() {
-        it("returns true for same content in map", function() {
-            var map1 = new Map();
-            var map2 = new Map();
+        context("when engine cannot compare Map instances", function() {
+            before(function() {
+                if (engineCanCompareMaps) {
+                    this.skip();
+                }
+            });
 
-            map1.set(42, "sinon");
-            map2.set(42, "sinon");
+            it("throws an error", function() {
+                var map1 = new Map();
+                var map2 = new Map();
 
-            assert.isTrue(samsam.match(map1, map2));
+                map1.set(42, "sinon");
+                map2.set(42, "sinon");
+
+                assert.exception(function() {
+                    samsam.match(map1, map2);
+                }, /The JavaScript engine does not support Array.from and cannot reliably do value comparison of Map instances/);
+            });
         });
 
-        it("returns true for same complex content in map", function() {
-            var map1 = new Map();
-            var map2 = new Map();
+        context("when engine can compare Map instances", function() {
+            before(function() {
+                if (!engineCanCompareMaps) {
+                    this.skip();
+                }
+            });
 
-            map1.set({ foo: "bar" }, "sinon");
-            map2.set({ foo: "bar" }, "sinon");
+            it("returns true for same content in map", function() {
+                var map1 = new Map();
+                var map2 = new Map();
 
-            assert.isTrue(samsam.match(map1, map2));
-        });
+                map1.set(42, "sinon");
+                map2.set(42, "sinon");
 
-        it("returns true for a supset of map", function() {
-            var map1 = new Map();
-            var map2 = new Map();
+                assert.isTrue(samsam.match(map1, map2));
+            });
 
-            map1.set(42, "sinon");
-            map1.set({ foo: "bar" }, "sinon");
-            map2.set({ foo: "bar" }, "sinon");
+            it("returns true for same complex content in map", function() {
+                var map1 = new Map();
+                var map2 = new Map();
 
-            assert.isTrue(samsam.match(map1, map2));
-        });
+                map1.set({ foo: "bar" }, "sinon");
+                map2.set({ foo: "bar" }, "sinon");
 
-        it("returns false for content in different order", function() {
-            var map1 = new Map();
-            var map2 = new Map();
+                assert.isTrue(samsam.match(map1, map2));
+            });
 
-            map1.set(42, "sinon");
-            map1.set("foo", "bar");
+            it("returns true for a supset of map", function() {
+                var map1 = new Map();
+                var map2 = new Map();
 
-            map2.set("foo", "bar");
-            map2.set(42, "sinon");
+                map1.set(42, "sinon");
+                map1.set({ foo: "bar" }, "sinon");
+                map2.set({ foo: "bar" }, "sinon");
 
-            assert.isFalse(samsam.match(map1, map2));
-        });
+                assert.isTrue(samsam.match(map1, map2));
+            });
 
-        it("returns false for maps with dissimilar content", function() {
-            var map1 = new Map();
-            var map2 = new Map();
+            it("returns false for content in different order", function() {
+                var map1 = new Map();
+                var map2 = new Map();
 
-            map1.set(42, "sinon");
-            map2.set("sinon", 42);
+                map1.set(42, "sinon");
+                map1.set("foo", "bar");
 
-            assert.isFalse(samsam.match(map1, map2));
-        });
+                map2.set("foo", "bar");
+                map2.set(42, "sinon");
 
-        it("returns false if the subset has more entries", function() {
-            var map1 = new Map();
-            var map2 = new Map();
+                assert.isFalse(samsam.match(map1, map2));
+            });
 
-            map1.set({ foo: "bar" }, "sinon");
-            map2.set(42, "sinon");
-            map2.set({ foo: "bar" }, "sinon");
+            it("returns false for maps with dissimilar content", function() {
+                var map1 = new Map();
+                var map2 = new Map();
 
-            assert.isFalse(samsam.match(map1, map2));
-        });
+                map1.set(42, "sinon");
+                map2.set("sinon", 42);
 
-        it("returns false on map compared with something else", function() {
-            var map = new Map();
+                assert.isFalse(samsam.match(map1, map2));
+            });
 
-            map.set(42, "sinon");
-            map.set("foo", "bar");
+            it("returns false if the subset has more entries", function() {
+                var map1 = new Map();
+                var map2 = new Map();
 
-            assert.isFalse(samsam.match(map, "string"));
-            assert.isFalse(samsam.match(map, true));
-            assert.isFalse(samsam.match(map, false));
-            assert.isFalse(samsam.match(map, 123));
+                map1.set({ foo: "bar" }, "sinon");
+                map2.set(42, "sinon");
+                map2.set({ foo: "bar" }, "sinon");
+
+                assert.isFalse(samsam.match(map1, map2));
+            });
+
+            it("returns false on map compared with something else", function() {
+                var map = new Map();
+
+                map.set(42, "sinon");
+                map.set("foo", "bar");
+
+                assert.isFalse(samsam.match(map, "string"));
+                assert.isFalse(samsam.match(map, true));
+                assert.isFalse(samsam.match(map, false));
+                assert.isFalse(samsam.match(map, 123));
+            });
         });
     });
 


### PR DESCRIPTION
This PR adds a warning to not use `samsam.match` with `Map` in un-supporting engines (IE11).

If there's consensus from the maintainers that this is a reasonable solution, then I'll add some tests to the PR.

#### Purpose (TL;DR) - mandatory

Prevent obscure errors in IE11 and warn end user that `samsam.match` cannot do anything meaningful when called with `Map` instances in IE11.

#### Background (Problem in detail)  - optional

When running tests in IE11, I am seeing a bunch of errors because of missing `Array.from`:

```
2) match
       Map
         returns true for same content in map:
     TypeError: Object doesn't support property or method 'from'
      at match (lib/match.js:108)
      at Anonymous function (lib/match.test.js:527)

  3) match
       Map
         returns true for same complex content in map:
     TypeError: Object doesn't support property or method 'from'
      at match (lib/match.js:108)
      at Anonymous function (lib/match.test.js:537)

  4) match
       Map
         returns true for a supset of map:
     TypeError: Object doesn't support property or method 'from'
      at match (lib/match.js:108)
      at Anonymous function (lib/match.test.js:548)

  5) match
       Map
         returns false for content in different order:
     TypeError: Object doesn't support property or method 'from'
      at match (lib/match.js:108)
      at Anonymous function (lib/match.test.js:561)

  6) match
       Map
         returns false for maps with dissimilar content:
     TypeError: Object doesn't support property or method 'from'
      at match (lib/match.js:108)
      at Anonymous function (lib/match.test.js:571)

  7) match
       Map
         returns false if the subset has more entries:
     TypeError: Object doesn't support property or method 'from'
      at match (lib/match.js:108)
      at Anonymous function (lib/match.test.js:582)

```

#### Solution

I've tried using an `array-from` polyfill (which we're installing, but not using?), and even `es6-map`. See https://github.com/sinonjs/samsam/compare/polyfill-array-from

IE11 has really poor support for Map, it is missing `.entries`, `.keys` and `.values`. Further, it also lacks support of `Array.from`.

I think getting value (egal) comparison of `Map` in IE11 is a lost cause. A partial implementation in IE makes it impossible to properly ponyfill (i.e. not overwrite the global `Map`) in `samsam`.

Even [the best polyfills of `Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#Polyfill) cannot fully deal with iterables like Map.

Therefore, without a proper implementation of `Map`, we can't reliably do a value (egal) comparison of `Map` instances.

Instead, we can warn the caller by throwing an error, when they try to match `Map` instances in an unsupporting engine.

#### How to verify - mandatory

1. Check out this branch
2. `npm ci`
3. `npm run test-cloud`
1. Observe that in IE11 there's a meaningful error message
