### PR TITLE
Matcher documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,10 +66,203 @@ Deep equal comparison. Two values are "deep equal" if:
   * `actual` can have [symbolic properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) that are missing from `expectation`
 
 
+### Matcher
+
+Match values and objects by type or or other fuzzy criteria. `samsam` ships
+with these built in matchers:
+
+#### `sinon.match.any`
+
+Matches anything.
+
+
+#### `sinon.match.defined`
+
+Requires the value to be defined.
+
+
+#### `sinon.match.truthy`
+
+Requires the value to be truthy.
+
+
+#### `sinon.match.falsy`
+
+Requires the value to be falsy.
+
+
+#### `sinon.match.bool`
+
+Requires the value to be a `Boolean`
+
+
+#### `sinon.match.number`
+
+Requires the value to be a `Number`.
+
+
+#### `sinon.match.string`
+
+Requires the value to be a `String`.
+
+
+#### `sinon.match.object`
+
+Requires the value to be an `Object`.
+
+
+#### `sinon.match.func`
+
+Requires the value to be a `Function`.
+
+
+#### `sinon.match.array`
+
+Requires the value to be an `Array`.
+
+
+#### `sinon.match.array.deepEquals(arr)`
+
+Requires an `Array` to be deep equal another one.
+
+
+#### `sinon.match.array.startsWith(arr)`
+
+Requires an `Array` to start with the same values as another one.
+
+
+#### `sinon.match.array.endsWith(arr)`
+
+Requires an `Array` to end with the same values as another one.
+
+
+#### `sinon.match.array.contains(arr)`
+
+Requires an `Array` to contain each one of the values the given array has.
+
+
+#### `sinon.match.map`
+
+Requires the value to be a `Map`.
+
+
+#### `sinon.match.map.deepEquals(map)`
+
+Requires a `Map` to be deep equal another one.
+
+#### `sinon.match.map.contains(map)`
+
+Requires a `Map` to contain each one of the items the given map has.
+
+
+#### `sinon.match.set`
+
+Requires the value to be a `Set`.
+
+
+#### `sinon.match.set.deepEquals(set)`
+
+Requires a `Set` to be deep equal another one.
+
+
+#### `sinon.match.set.contains(set)`
+
+Requires a `Set` to contain each one of the items the given set has.
+
+
+#### `sinon.match.regexp`
+
+Requires the value to be a regular expression.
+
+
+#### `sinon.match.date`
+
+Requires the value to be a `Date` object.
+
+
+#### `sinon.match.symbol`
+
+Requires the value to be a `Symbol`.
+
+#### `sinon.match.in(array)`
+
+Requires the value to be in the `array`.
+
+#### `sinon.match.same(ref)`
+
+Requires the value to strictly equal `ref`.
+
+#### `sinon.match.typeOf(type)`
+
+Requires the value to be of the given type, where `type` can be one of
+    `"undefined"`,
+    `"null"`,
+    `"boolean"`,
+    `"number"`,
+    `"string"`,
+    `"object"`,
+    `"function"`,
+    `"array"`,
+    `"regexp"`,
+    `"date"` or
+    `"symbol"`.
+
+
+#### `sinon.match.instanceOf(type)`
+
+Requires the value to be an instance of the given `type`.
+
+#### `sinon.match.has(property[, expectation])`
+
+Requires the value to define the given `property`.
+
+The property might be inherited via the prototype chain. If the optional expectation is given, the value of the property is deeply compared with the expectation. The expectation can be another matcher.
+
+#### `sinon.match.hasOwn(property[, expectation])`
+
+Same as `sinon.match.has` but the property must be defined by the value itself. Inherited properties are ignored.
+
+
+#### `sinon.match.hasNested(propertyPath[, expectation])`
+
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
+
+The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
+
+
+```javascript
+sinon.match.hasNested("a[0].b.c");
+
+// Where actual is something like
+var actual = { "a": [{ "b": { "c": 3 } }] };
+
+sinon.match.hasNested("a.b.c");
+
+// Where actual is something like
+var actual = { "a": { "b": { "c": 3 } } };
+```
+
+#### `sinon.match.every(matcher)`
+
+Requires **every** element of an `Array`, `Set` or `Map`, or alternatively **every** value of an `Object` to match the given `matcher`.
+
+#### `sinon.match.some(matcher)`
+
+Requires **any** element of an `Array`, `Set` or `Map`, or alternatively **any** value of an `Object` to match the given `matcher`.
+
+## Combining matchers
+
+All matchers implement `and` and `or`. This allows to logically combine mutliple matchers. The result is a new matchers that requires both (and) or one of the matchers (or) to return `true`.
+
+```javascript
+var stringOrNumber = sinon.match.string.or(sinon.match.number);
+var bookWithPages = sinon.match.instanceOf(Book).and(sinon.match.has("pages"));
+```
+
 ### `match(object, matcher)`
 
-Partial equality check. Compares `object` with matcher according a wide set of
-rules:
+Creates a custom matcher to perform partial equality check. Compares `object`
+with matcher according a wide set of rules:
 
 #### String matcher
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@
 identifiying the type of values and to compare values with varying degrees of
 strictness.
 
-`samsam` is a general-purpose library with no dependencies. It works in browsers
-(including old and rowdy ones, like IE6) and Node. It will define itself as an
-AMD module if you want it to (i.e. if there's a `define` function available).
+`samsam` is a general-purpose library. It works in browsers and Node. It will
+define itself as an AMD module if you want it to (i.e. if there's a `define`
+function available).
 
 ## Predicate functions
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Some quick and easy documentation improvements

- We've been lying about dependencies and IE6 support for some time now.
- The matchers documentation was missing the pre defined matchers. I've copied the relevant section from the Sinon docs.
