### PR TITLE
Add Support for TypedArrays

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -12,6 +12,15 @@ globals:
   Set: false
   Symbol: false
   BigInt: false
+  Int8Array: false
+  Uint8Array: false
+  Uint8ClampedArray: false
+  Int16Array: false
+  Uint16Array: false
+  Int32Array: false
+  Uint32Array: false
+  Float32Array: false
+  Float64Array: false
 
 plugins:
   - ie11

--- a/lib/array-types.js
+++ b/lib/array-types.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var ARRAY_TYPES = [
+    Array,
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array
+];
+
+module.exports = ARRAY_TYPES;

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -3,6 +3,9 @@
 var assert = require("@sinonjs/referee").assert;
 var createSet = require("./create-set");
 var createMatcher = require("./create-matcher");
+var forEach = require("@sinonjs/commons").prototypes.array.forEach;
+var functionName = require("@sinonjs/commons").functionName;
+var ARRAY_TYPES = require("./array-types");
 
 var samsam = require("./samsam");
 
@@ -232,27 +235,6 @@ describe("deepEqual", function() {
     it("returns false for error and object", function() {
         assert.isFalse(samsam.deepEqual(createError(), {}));
         assert.isFalse(samsam.deepEqual({}, createError()));
-    });
-
-    it("returns true if arrays", function() {
-        var checkDeep = samsam.deepEqual(
-            [1, 2, "Hey there", func, { id: 42, prop: [2, 3] }],
-            [1, 2, "Hey there", func, { id: 42, prop: [2, 3] }]
-        );
-        assert.isTrue(checkDeep);
-    });
-
-    it("returns false if nested array with shallow array", function() {
-        var checkDeep = samsam.deepEqual([["hey"]], ["hey"]);
-        assert.isFalse(checkDeep);
-    });
-
-    it("returns false if arrays with different custom properties", function() {
-        var arr1 = [1, 2, 3];
-        var arr2 = [1, 2, 3];
-        arr1.prop = 42;
-        var checkDeep = samsam.deepEqual(arr1, arr2);
-        assert.isFalse(checkDeep);
     });
 
     it("returns true if regexp literals", function() {
@@ -828,6 +810,79 @@ describe("deepEqual", function() {
             cyclic2.ref.ref = cyclic2.ref;
             var checkDeep = samsam.deepEqual(cyclic1, cyclic2);
             assert.isFalse(checkDeep);
+        });
+    });
+
+    describe("arrays", function() {
+        function instantiate(Klass) {
+            return function(value) {
+                return new Klass(value);
+            };
+        }
+        forEach(ARRAY_TYPES, function(value, index) {
+            before(function() {
+                if (typeof value === "undefined") {
+                    this.skip();
+                }
+            });
+            var createArray = instantiate(value);
+
+            describe(functionName(value), function() {
+                it("returns true on same typed array", function() {
+                    var array = createArray([0, 1]);
+                    var checkDeep = samsam.deepEqual(array, array);
+                    assert.isTrue(checkDeep);
+                });
+
+                it("returns true on identical content", function() {
+                    var checkDeep = samsam.deepEqual(
+                        createArray([0, 1]),
+                        createArray([0, 1])
+                    );
+                    assert.isTrue(checkDeep);
+                });
+
+                it("returns false on different content", function() {
+                    var checkDeep = samsam.deepEqual(
+                        createArray([0, 1]),
+                        createArray([0])
+                    );
+                    assert.isFalse(checkDeep);
+                });
+
+                it("returns false if arrays with different custom properties", function() {
+                    var array1 = createArray([0, 1]);
+                    var array2 = createArray([0, 1]);
+                    array1.prop = 42;
+                    var checkDeep = samsam.deepEqual(array1, array2);
+                    assert.isFalse(checkDeep);
+                });
+
+                it("returns false on different types", function() {
+                    var precursor =
+                        (index === 0 ? ARRAY_TYPES.length : index) - 1;
+                    var checkDeep = samsam.deepEqual(
+                        createArray([0, 1]),
+                        instantiate(ARRAY_TYPES[precursor])([0, 1])
+                    );
+                    assert.isFalse(checkDeep);
+                });
+            });
+        });
+
+        describe("with complex content", function() {
+            it("returns true if arrays", function() {
+                var checkDeep = samsam.deepEqual(
+                    [1, 2, "Hey there", func, { id: 42, prop: [2, 3] }],
+                    [1, 2, "Hey there", func, { id: 42, prop: [2, 3] }]
+                );
+                assert.isTrue(checkDeep);
+            });
+
+            it("returns false if nested array with shallow array", function() {
+                var checkDeep = samsam.deepEqual([["hey"]], ["hey"]);
+                assert.isFalse(checkDeep);
+            });
         });
     });
 });

--- a/lib/is-array-type.js
+++ b/lib/is-array-type.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var functionName = require("@sinonjs/commons").functionName;
+var indexOf = require("@sinonjs/commons").prototypes.array.indexOf;
+var map = require("@sinonjs/commons").prototypes.array.map;
+var ARRAY_TYPES = require("./array-types");
+var type = require("type-detect");
+
+/**
+ * Returns `true` when `object` is an array type, `false` otherwise
+ *
+ * @param  {*}  object - The object to examine
+ * @returns {boolean} `true` when `object` is an array type
+ * @private
+ */
+function isArrayType(object) {
+    return indexOf(map(ARRAY_TYPES, functionName), type(object)) !== -1;
+}
+
+module.exports = isArrayType;

--- a/lib/is-array-type.test.js
+++ b/lib/is-array-type.test.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var assert = require("@sinonjs/referee").assert;
+var forEach = require("@sinonjs/commons").prototypes.array.forEach;
+var functionName = require("@sinonjs/commons").functionName;
+
+var ARRAY_TYPES = require("./array-types");
+var isArrayType = require("./is-array-type");
+
+describe("isArrayType", function() {
+    forEach(ARRAY_TYPES, function(ArrayType) {
+        context("given " + functionName(ArrayType), function() {
+            it("returns true", function() {
+                assert.isTrue(isArrayType(new ArrayType([])));
+            });
+        });
+    });
+
+    context("given other types", function() {
+        it("returns false", function() {
+            assert.isFalse(isArrayType(null));
+            assert.isFalse(isArrayType("string"));
+            assert.isFalse(isArrayType(42));
+            assert.isFalse(isArrayType({}));
+            assert.isFalse(isArrayType(/sinon/));
+        });
+    });
+});

--- a/lib/match.js
+++ b/lib/match.js
@@ -7,6 +7,7 @@ var type = require("type-detect");
 
 var engineCanCompareMaps = typeof Array.from === "function";
 var deepEqual = require("./deep-equal").use(match); // eslint-disable-line no-use-before-define
+var isArrayType = require("./is-array-type");
 var isSubset = require("./is-subset");
 var createMatcher = require("./create-matcher");
 
@@ -76,14 +77,6 @@ function match(object, matcherOrValue) {
             return object === null;
         case "undefined":
             return typeof object === "undefined";
-        case "Array":
-            /* istanbul ignore else */
-            if (type(object) === "Array") {
-                return arrayContains(object, matcherOrValue, match);
-            }
-
-            /* istanbul ignore next: this is basically the rest of the function, which is covered */
-            break;
         case "Date":
             /* istanbul ignore else */
             if (type(object) === "Date") {
@@ -91,6 +84,20 @@ function match(object, matcherOrValue) {
             }
             /* istanbul ignore next: this is basically the rest of the function, which is covered */
             break;
+        case "Array":
+        case "Int8Array":
+        case "Uint8Array":
+        case "Uint8ClampedArray":
+        case "Int16Array":
+        case "Uint16Array":
+        case "Int32Array":
+        case "Uint32Array":
+        case "Float32Array":
+        case "Float64Array":
+            return (
+                isArrayType(matcherOrValue) &&
+                arrayContains(object, matcherOrValue, match)
+            );
         case "Map":
             /* istanbul ignore next: this is covered by a test, that is only run in IE, but we collect coverage information in node*/
             if (!engineCanCompareMaps) {

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -1,10 +1,12 @@
 "use strict";
 
 var assert = require("@sinonjs/referee").assert;
-
+var forEach = require("@sinonjs/commons").prototypes.array.forEach;
+var functionName = require("@sinonjs/commons").functionName;
 var createSet = require("./create-set");
 var engineCanCompareMaps = typeof Array.from === "function";
 var samsam = require("./samsam");
+var ARRAY_TYPES = require("./array-types");
 
 describe("match", function() {
     it("returns true if matching regexp", function() {
@@ -254,57 +256,104 @@ describe("match", function() {
         assert.isTrue(checkMatch);
     });
 
-    it("returns true if similar arrays", function() {
-        var checkMatch = samsam.match([1, 2, 3], [1, 2, 3]);
-        assert.isTrue(checkMatch);
-    });
+    describe("arrays", function() {
+        function instantiate(Klass) {
+            return function(value) {
+                return new Klass(value);
+            };
+        }
+        forEach(ARRAY_TYPES, function(value) {
+            before(function() {
+                if (typeof value === "undefined") {
+                    this.skip();
+                }
+            });
+            var createArray = instantiate(value);
 
-    it("returns true if array subset", function() {
-        var checkMatch = samsam.match([1, 2, 3], [2, 3]);
-        assert.isTrue(checkMatch);
-    });
+            describe(functionName(value), function() {
+                it("returns true if similar arrays", function() {
+                    var checkMatch = samsam.match(
+                        createArray([1, 2, 3]),
+                        createArray([1, 2, 3])
+                    );
+                    assert.isTrue(checkMatch);
+                });
 
-    it("returns true if single-element array subset", function() {
-        var checkMatch = samsam.match([1, 2, 3], [1]);
-        assert.isTrue(checkMatch);
-    });
+                it("returns true if array subset", function() {
+                    var checkMatch = samsam.match(
+                        createArray([1, 2, 3]),
+                        createArray([2, 3])
+                    );
+                    assert.isTrue(checkMatch);
+                });
 
-    it("returns false if subset array does not include a match", function() {
-        var checkMatch = samsam.match([1, 2, 3], [4]);
-        assert.isFalse(checkMatch);
-    });
+                it("returns true if single-element array subset", function() {
+                    var checkMatch = samsam.match(
+                        createArray([1, 2, 3]),
+                        createArray([1])
+                    );
+                    assert.isTrue(checkMatch);
+                });
 
-    it("returns true if matching array subset", function() {
-        var checkMatch = samsam.match([1, 2, 3, { id: 42 }], [{ id: 42 }]);
-        assert.isTrue(checkMatch);
-    });
+                it("returns false if subset array does not include a match", function() {
+                    var checkMatch = samsam.match(
+                        createArray([1, 2, 3]),
+                        createArray([4])
+                    );
+                    assert.isFalse(checkMatch);
+                });
 
-    it("returns false if mis-matching array 'subset'", function() {
-        var checkMatch = samsam.match([1, 2, 3], [2, 3, 4]);
-        assert.isFalse(checkMatch);
-    });
+                it("returns false if mis-matching array 'subset'", function() {
+                    var checkMatch = samsam.match(
+                        createArray([1, 2, 3]),
+                        createArray([2, 3, 4])
+                    );
+                    assert.isFalse(checkMatch);
+                });
 
-    it("returns false if mis-ordered array 'subset'", function() {
-        var checkMatch = samsam.match([1, 2, 3], [1, 3]);
-        assert.isFalse(checkMatch);
-    });
+                it("returns false if mis-ordered array 'subset'", function() {
+                    var checkMatch = samsam.match(
+                        createArray([1, 2, 3]),
+                        createArray([1, 3])
+                    );
+                    assert.isFalse(checkMatch);
+                });
 
-    it("returns false if mis-ordered, but similar arrays of objects", function() {
-        var checkMatch = samsam.match(
-            [{ a: "a" }, { a: "aa" }],
-            [{ a: "aa" }, { a: "a" }]
-        );
-        assert.isFalse(checkMatch);
-    });
+                it("returns true if empty arrays", function() {
+                    var checkMatch = samsam.match(
+                        createArray([]),
+                        createArray([])
+                    );
+                    assert.isTrue(checkMatch);
+                });
 
-    it("returns true if empty arrays", function() {
-        var checkMatch = samsam.match([], []);
-        assert.isTrue(checkMatch);
-    });
+                it("returns false if subset length is more than array length", function() {
+                    var checkMatch = samsam.match(
+                        createArray([]),
+                        createArray([0])
+                    );
+                    assert.isFalse(checkMatch);
+                });
+            });
+        });
 
-    it("returns false if subset length is more than array length", function() {
-        var checkMatch = samsam.match([], [0]);
-        assert.isFalse(checkMatch);
+        describe("with complex content", function() {
+            it("returns true if matching array subset", function() {
+                var checkMatch = samsam.match(
+                    [1, 2, 3, { id: 42 }],
+                    [{ id: 42 }]
+                );
+                assert.isTrue(checkMatch);
+            });
+
+            it("returns false if mis-ordered, but similar arrays of objects", function() {
+                var checkMatch = samsam.match(
+                    [{ a: "a" }, { a: "aa" }],
+                    [{ a: "aa" }, { a: "a" }]
+                );
+                assert.isFalse(checkMatch);
+            });
+        });
     });
 
     it("returns true if objects with empty arrays", function() {


### PR DESCRIPTION
This PR is a _Draft_ of improving `samsam` to detect more array types.

Support covers almost all Types of [typed arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays). Every Type is tested separatly (which increases the amount of tests alot, as seen for `match`).

While developing I was questioning if this really belongs into `samsam` or would make more sense in separat/dedicated package like `samsam-typed-arrays` or `samsam-extra-array`.

@mantoni @mroderick any thoughts?


