### PR TITLE
Refactor match

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -3,13 +3,10 @@
 var valueToString = require("@sinonjs/commons").valueToString;
 var indexOf = require("@sinonjs/commons").prototypes.string.indexOf;
 var forEach = require("@sinonjs/commons").prototypes.array.forEach;
+var type = require("type-detect");
 
 var engineCanCompareMaps = typeof Array.from === "function";
 var deepEqual = require("./deep-equal").use(match); // eslint-disable-line no-use-before-define
-var getClass = require("./get-class");
-var isDate = require("./is-date");
-var isSet = require("./is-set");
-var isMap = require("./is-map");
 var isSubset = require("./is-subset");
 var createMatcher = require("./create-matcher");
 
@@ -58,74 +55,69 @@ function match(object, matcherOrValue) {
         return matcherOrValue.test(object);
     }
 
-    if (typeof matcherOrValue === "function") {
-        return matcherOrValue(object) === true;
-    }
-
-    if (typeof matcherOrValue === "string") {
-        var notNull = typeof object === "string" || Boolean(object);
-        return (
-            notNull &&
-            indexOf(
-                valueToString(object).toLowerCase(),
-                matcherOrValue.toLowerCase()
-            ) >= 0
-        );
-    }
-
-    if (typeof matcherOrValue === "number") {
-        return matcherOrValue === object;
-    }
-
-    if (typeof matcherOrValue === "boolean") {
-        return matcherOrValue === object;
-    }
-
-    if (typeof matcherOrValue === "bigint") {
-        return matcherOrValue === object;
-    }
-
-    if (typeof matcherOrValue === "undefined") {
-        return typeof object === "undefined";
-    }
-
-    if (typeof matcherOrValue === "symbol") {
-        return matcherOrValue === object;
-    }
-
-    if (matcherOrValue === null) {
-        return object === null;
-    }
-
-    if (object === null) {
-        return false;
-    }
-
-    if (isSet(object)) {
-        return isSubset(matcherOrValue, object, match);
-    }
-
-    if (isMap(object)) {
-        // this is covered by a test, that is only run in IE, but we collect coverage information in node
-        /* istanbul ignore next */
-        if (!engineCanCompareMaps) {
-            throw new Error(
-                "The JavaScript engine does not support Array.from and cannot reliably do value comparison of Map instances"
+    switch (type(matcherOrValue)) {
+        case "bigint":
+        case "boolean":
+        case "number":
+        case "symbol":
+            return matcherOrValue === object;
+        case "function":
+            return matcherOrValue(object) === true;
+        case "string":
+            var notNull = typeof object === "string" || Boolean(object);
+            return (
+                notNull &&
+                indexOf(
+                    valueToString(object).toLowerCase(),
+                    matcherOrValue.toLowerCase()
+                ) >= 0
             );
-        }
+        case "null":
+            return object === null;
+        case "undefined":
+            return typeof object === "undefined";
+        case "Array":
+            /* istanbul ignore else */
+            if (type(object) === "Array") {
+                return arrayContains(object, matcherOrValue, match);
+            }
 
-        return (
-            isMap(matcherOrValue) &&
-            arrayContains(Array.from(object), Array.from(matcherOrValue), match)
-        );
+            /* istanbul ignore next: this is basically the rest of the function, which is covered */
+            break;
+        case "Date":
+            /* istanbul ignore else */
+            if (type(object) === "Date") {
+                return object.getTime() === matcherOrValue.getTime();
+            }
+            /* istanbul ignore next: this is basically the rest of the function, which is covered */
+            break;
+        case "Map":
+            /* istanbul ignore next: this is covered by a test, that is only run in IE, but we collect coverage information in node*/
+            if (!engineCanCompareMaps) {
+                throw new Error(
+                    "The JavaScript engine does not support Array.from and cannot reliably do value comparison of Map instances"
+                );
+            }
+
+            return (
+                type(object) === "Map" &&
+                arrayContains(
+                    Array.from(object),
+                    Array.from(matcherOrValue),
+                    match
+                )
+            );
+        default:
+            break;
     }
 
-    if (getClass(object) === "Array" && getClass(matcherOrValue) === "Array") {
-        return arrayContains(object, matcherOrValue, match);
-    }
-
-    if (isDate(matcherOrValue)) {
-        return isDate(object) && object.getTime() === matcherOrValue.getTime();
+    switch (type(object)) {
+        case "null":
+            return false;
+        case "Set":
+            return isSubset(matcherOrValue, object, match);
+        default:
+            break;
     }
 
     /* istanbul ignore else */

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   ],
   "dependencies": {
     "@sinonjs/commons": "^1.6.0",
-    "lodash.get": "^4.4.2"
+    "lodash.get": "^4.4.2",
+    "type-detect": "^4.0.8"
   },
   "devDependencies": {
     "@sinonjs/referee": "^3.2.0",


### PR DESCRIPTION
Simplify `match` by using `type-detect` and a `switch` statement

#### Background

The `match` function is getting longer and more complex. This refactoring pulls it back slightly. There is lots more we can do, but I think this is a good start and will allow #143 to get merged sooner.

#### Aside

I think we should make greater use of `type-detect`, and consider using that in all `Sinon` projects, instead of `samsam.isX` functions. Perhaps even create a new major version of `samsam` without these functions.

#### How to verify

1. Check out this branch
1. `npm ci`
1. `npm run test-cloud`
1. Observe that tests pass
