### PR TITLE
Refactor to use type-detect

### DIFF
--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -7,8 +7,8 @@ var functionName = require("@sinonjs/commons").functionName;
 var get = require("lodash.get");
 var iterableToString = require("./iterable-to-string");
 var objectProto = require("@sinonjs/commons").prototypes.object;
-var typeOf = require("@sinonjs/commons").typeOf;
 var valueToString = require("@sinonjs/commons").valueToString;
+var type = require("type-detect");
 
 var assertMatcher = require("./create-matcher/assert-matcher");
 var assertMethodExists = require("./create-matcher/assert-method-exists");
@@ -36,9 +36,9 @@ var TYPE_MAP = require("./create-matcher/type-map");
  */
 function createMatcher(expectation, message) {
     var m = Object.create(matcherPrototype);
-    var type = typeOf(expectation);
+    var expectationType = type(expectation);
 
-    if (message !== undefined && typeof message !== "string") {
+    if (message !== undefined && type(message) !== "string") {
         throw new TypeError("Message should be a string");
     }
 
@@ -48,8 +48,8 @@ function createMatcher(expectation, message) {
         );
     }
 
-    if (type in TYPE_MAP) {
-        TYPE_MAP[type](m, expectation, message);
+    if (expectationType in TYPE_MAP) {
+        TYPE_MAP[expectationType](m, expectation, message);
     } else {
         m.test = function(actual) {
             return deepEqual(actual, expectation);
@@ -88,7 +88,7 @@ createMatcher.same = function(expectation) {
 };
 
 createMatcher.in = function(arrayOfExpectations) {
-    if (typeOf(arrayOfExpectations) !== "array") {
+    if (type(arrayOfExpectations) !== "Array") {
         throw new TypeError("array expected");
     }
 
@@ -99,31 +99,33 @@ createMatcher.in = function(arrayOfExpectations) {
     }, "in(" + valueToString(arrayOfExpectations) + ")");
 };
 
-createMatcher.typeOf = function(type) {
-    assertType(type, "string", "type");
+createMatcher.typeOf = function(expectation) {
+    assertType(expectation, "string", "type");
     return createMatcher(function(actual) {
-        return typeOf(actual) === type;
-    }, 'typeOf("' + type + '")');
+        return type(actual) === expectation;
+    }, 'typeOf("' + expectation + '")');
 };
 
-createMatcher.instanceOf = function(type) {
+createMatcher.instanceOf = function(expectation) {
     /* istanbul ignore if */
     if (
         typeof Symbol === "undefined" ||
         typeof Symbol.hasInstance === "undefined"
     ) {
-        assertType(type, "function", "type");
+        assertType(expectation, "function", "type");
     } else {
         assertMethodExists(
-            type,
+            expectation,
             Symbol.hasInstance,
             "type",
             "[Symbol.hasInstance]"
         );
     }
     return createMatcher(function(actual) {
-        return actual instanceof type;
-    }, "instanceOf(" + (functionName(type) || objectToString(type)) + ")");
+        return actual instanceof expectation;
+    }, "instanceOf(" +
+        (functionName(expectation) || objectToString(expectation)) +
+        ")");
 };
 
 /**
@@ -157,7 +159,7 @@ function createPropertyMatcher(propertyTest, messagePrefix) {
 }
 
 createMatcher.has = createPropertyMatcher(function(actual, property) {
-    if (typeof actual === "object") {
+    if (type(actual) === "Object") {
         return property in actual;
     }
     return actual[property] !== undefined;
@@ -191,7 +193,7 @@ createMatcher.every = function(predicate) {
     assertMatcher(predicate);
 
     return createMatcher(function(actual) {
-        if (typeOf(actual) === "object") {
+        if (type(actual) === "Object") {
             return every(Object.keys(actual), function(key) {
                 return predicate.test(actual[key]);
             });
@@ -210,7 +212,7 @@ createMatcher.some = function(predicate) {
     assertMatcher(predicate);
 
     return createMatcher(function(actual) {
-        if (typeOf(actual) === "object") {
+        if (type(actual) === "Object") {
             return !every(Object.keys(actual), function(key) {
                 return !predicate.test(actual[key]);
             });
@@ -225,19 +227,18 @@ createMatcher.some = function(predicate) {
     }, "some(" + predicate.message + ")");
 };
 
-createMatcher.array = createMatcher.typeOf("array");
+createMatcher.array = createMatcher.typeOf("Array");
 
 createMatcher.array.deepEquals = function(expectation) {
     return createMatcher(function(actual) {
         // Comparing lengths is the fastest way to spot a difference before iterating through every item
         var sameLength = actual.length === expectation.length;
         return (
-            typeOf(actual) === "array" &&
+            type(actual) === "Array" &&
             sameLength &&
             every(actual, function(element, index) {
                 var expected = expectation[index];
-                return typeOf(expected) === "array" &&
-                    typeOf(element) === "array"
+                return type(expected) === "Array" && type(element) === "Array"
                     ? createMatcher.array.deepEquals(expected).test(element)
                     : deepEqual(expected, element);
             })
@@ -248,7 +249,7 @@ createMatcher.array.deepEquals = function(expectation) {
 createMatcher.array.startsWith = function(expectation) {
     return createMatcher(function(actual) {
         return (
-            typeOf(actual) === "array" &&
+            type(actual) === "Array" &&
             every(expectation, function(expectedElement, index) {
                 return actual[index] === expectedElement;
             })
@@ -262,7 +263,7 @@ createMatcher.array.endsWith = function(expectation) {
         var offset = actual.length - expectation.length;
 
         return (
-            typeOf(actual) === "array" &&
+            type(actual) === "Array" &&
             every(expectation, function(expectedElement, index) {
                 return actual[offset + index] === expectedElement;
             })
@@ -273,7 +274,7 @@ createMatcher.array.endsWith = function(expectation) {
 createMatcher.array.contains = function(expectation) {
     return createMatcher(function(actual) {
         return (
-            typeOf(actual) === "array" &&
+            type(actual) === "Array" &&
             every(expectation, function(expectedElement) {
                 return arrayIndexOf(actual, expectedElement) !== -1;
             })
@@ -281,14 +282,14 @@ createMatcher.array.contains = function(expectation) {
     }, "contains([" + iterableToString(expectation) + "])");
 };
 
-createMatcher.map = createMatcher.typeOf("map");
+createMatcher.map = createMatcher.typeOf("Map");
 
 createMatcher.map.deepEquals = function mapDeepEquals(expectation) {
     return createMatcher(function(actual) {
         // Comparing lengths is the fastest way to spot a difference before iterating through every item
         var sameLength = actual.size === expectation.size;
         return (
-            typeOf(actual) === "map" &&
+            type(actual) === "Map" &&
             sameLength &&
             every(actual, function(element, key) {
                 return expectation.has(key) && expectation.get(key) === element;
@@ -300,7 +301,7 @@ createMatcher.map.deepEquals = function mapDeepEquals(expectation) {
 createMatcher.map.contains = function mapContains(expectation) {
     return createMatcher(function(actual) {
         return (
-            typeOf(actual) === "map" &&
+            type(actual) === "Map" &&
             every(expectation, function(element, key) {
                 return actual.has(key) && actual.get(key) === element;
             })
@@ -308,14 +309,14 @@ createMatcher.map.contains = function mapContains(expectation) {
     }, "contains(Map[" + iterableToString(expectation) + "])");
 };
 
-createMatcher.set = createMatcher.typeOf("set");
+createMatcher.set = createMatcher.typeOf("Set");
 
 createMatcher.set.deepEquals = function setDeepEquals(expectation) {
     return createMatcher(function(actual) {
         // Comparing lengths is the fastest way to spot a difference before iterating through every item
         var sameLength = actual.size === expectation.size;
         return (
-            typeOf(actual) === "set" &&
+            type(actual) === "Set" &&
             sameLength &&
             every(actual, function(element) {
                 return expectation.has(element);
@@ -327,7 +328,7 @@ createMatcher.set.deepEquals = function setDeepEquals(expectation) {
 createMatcher.set.contains = function setContains(expectation) {
     return createMatcher(function(actual) {
         return (
-            typeOf(actual) === "set" &&
+            type(actual) === "Set" &&
             every(expectation, function(element) {
                 return actual.has(element);
             })
@@ -338,10 +339,10 @@ createMatcher.set.contains = function setContains(expectation) {
 createMatcher.bool = createMatcher.typeOf("boolean");
 createMatcher.number = createMatcher.typeOf("number");
 createMatcher.string = createMatcher.typeOf("string");
-createMatcher.object = createMatcher.typeOf("object");
+createMatcher.object = createMatcher.typeOf("Object");
 createMatcher.func = createMatcher.typeOf("function");
-createMatcher.regexp = createMatcher.typeOf("regexp");
-createMatcher.date = createMatcher.typeOf("date");
+createMatcher.regexp = createMatcher.typeOf("RegExp");
+createMatcher.date = createMatcher.typeOf("Date");
 createMatcher.symbol = createMatcher.typeOf("symbol");
 
 module.exports = createMatcher;

--- a/lib/create-matcher.test.js
+++ b/lib/create-matcher.test.js
@@ -564,13 +564,13 @@ describe("matcher", function() {
         });
 
         it("returns true if test is called with regexp", function() {
-            var typeOf = createMatcher.typeOf("regexp");
+            var typeOf = createMatcher.typeOf("RegExp");
 
             assert(typeOf.test(/.+/));
         });
 
         it("returns false if test is not called with regexp", function() {
-            var typeOf = createMatcher.typeOf("regexp");
+            var typeOf = createMatcher.typeOf("RegExp");
 
             assert.isFalse(typeOf.test(true));
         });
@@ -946,7 +946,7 @@ describe("matcher", function() {
             var object = createMatcher.object;
 
             assert(createMatcher.isMatcher(object));
-            assert.equals(object.toString(), 'typeOf("object")');
+            assert.equals(object.toString(), 'typeOf("Object")');
         });
     });
 
@@ -964,7 +964,7 @@ describe("matcher", function() {
             var array = createMatcher.array;
 
             assert(createMatcher.isMatcher(array));
-            assert.equals(array.toString(), 'typeOf("array")');
+            assert.equals(array.toString(), 'typeOf("Array")');
         });
 
         describe("array.deepEquals", function() {
@@ -1133,7 +1133,7 @@ describe("matcher", function() {
             var map = createMatcher.map;
 
             assert(createMatcher.isMatcher(map));
-            assert.equals(map.toString(), 'typeOf("map")');
+            assert.equals(map.toString(), 'typeOf("Map")');
         });
 
         describe("map.deepEquals", function() {
@@ -1282,7 +1282,7 @@ describe("matcher", function() {
             var set = createMatcher.set;
 
             assert(createMatcher.isMatcher(set));
-            assert.equals(set.toString(), 'typeOf("set")');
+            assert.equals(set.toString(), 'typeOf("Set")');
         });
 
         describe("set.deepEquals", function() {
@@ -1386,7 +1386,7 @@ describe("matcher", function() {
             var regexp = createMatcher.regexp;
 
             assert(createMatcher.isMatcher(regexp));
-            assert.equals(regexp.toString(), 'typeOf("regexp")');
+            assert.equals(regexp.toString(), 'typeOf("RegExp")');
         });
     });
 
@@ -1395,7 +1395,7 @@ describe("matcher", function() {
             var date = createMatcher.date;
 
             assert(createMatcher.isMatcher(date));
-            assert.equals(date.toString(), 'typeOf("date")');
+            assert.equals(date.toString(), 'typeOf("Date")');
         });
     });
 

--- a/lib/create-matcher/assert-type.js
+++ b/lib/create-matcher/assert-type.js
@@ -1,25 +1,25 @@
 "use strict";
 
-var typeOf = require("@sinonjs/commons").typeOf;
+var type = require("type-detect");
 
 /**
  * Ensures that value is of type
  *
  * @private
  * @param {*} value A value to examine
- * @param {string} type A basic JavaScript type to compare to, e.g. "object", "string"
+ * @param {string} expected A basic JavaScript type to compare to, e.g. "object", "string"
  * @param {string} name A string to use for the error message
  * @throws {TypeError} If value is not of the expected type
  * @returns {undefined}
  */
-function assertType(value, type, name) {
-    var actual = typeOf(value);
-    if (actual !== type) {
+function assertType(value, expected, name) {
+    var actual = type(value);
+    if (actual !== expected) {
         throw new TypeError(
             "Expected type of " +
                 name +
                 " to be " +
-                type +
+                expected +
                 ", but was " +
                 actual
         );

--- a/lib/create-matcher/is-iterable.js
+++ b/lib/create-matcher/is-iterable.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var typeOf = require("@sinonjs/commons").typeOf;
+var type = require("type-detect");
 
 /**
  * Returns `true` for iterables
@@ -10,7 +10,7 @@ var typeOf = require("@sinonjs/commons").typeOf;
  * @returns {boolean} Returns `true` when `value` looks like an iterable
  */
 function isIterable(value) {
-    return Boolean(value) && typeOf(value.forEach) === "function";
+    return Boolean(value) && type(value.forEach) === "function";
 }
 
 module.exports = isIterable;

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var every = require("@sinonjs/commons").prototypes.array.every;
-var typeOf = require("@sinonjs/commons").typeOf;
+var type = require("type-detect");
 
 var deepEqual = require("../deep-equal");
 
@@ -27,7 +27,7 @@ function matchObject(actual, expectation) {
             if (!exp.test(act)) {
                 return false;
             }
-        } else if (typeOf(exp) === "object") {
+        } else if (type(exp) === "Object") {
             if (!matchObject(act, exp)) {
                 return false;
             }

--- a/lib/create-matcher/type-map.js
+++ b/lib/create-matcher/type-map.js
@@ -5,6 +5,7 @@ var join = require("@sinonjs/commons").prototypes.array.join;
 var map = require("@sinonjs/commons").prototypes.array.map;
 var stringIndexOf = require("@sinonjs/commons").prototypes.string.indexOf;
 var valueToString = require("@sinonjs/commons").valueToString;
+var type = require("type-detect");
 
 var matchObject = require("./match-object");
 
@@ -19,10 +20,10 @@ var TYPE_MAP = {
             return expectation == actual; // eslint-disable-line eqeqeq
         };
     },
-    object: function(m, expectation) {
+    Object: function(m, expectation) {
         var array = [];
 
-        if (typeof expectation.test === "function") {
+        if (type(expectation.test) === "function") {
             m.test = function(actual) {
                 return expectation.test(actual) === true;
             };
@@ -41,15 +42,15 @@ var TYPE_MAP = {
 
         return m;
     },
-    regexp: function(m, expectation) {
+    RegExp: function(m, expectation) {
         m.test = function(actual) {
-            return typeof actual === "string" && expectation.test(actual);
+            return type(actual) === "string" && expectation.test(actual);
         };
     },
     string: function(m, expectation) {
         m.test = function(actual) {
             return (
-                typeof actual === "string" &&
+                type(actual) === "string" &&
                 stringIndexOf(actual, expectation) !== -1
             );
         };

--- a/lib/create-set.js
+++ b/lib/create-set.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var typeOf = require("@sinonjs/commons").typeOf;
 var forEach = require("@sinonjs/commons").prototypes.array.forEach;
+var type = require("type-detect");
 
 /**
  * This helper makes it convenient to create Set instances from a
@@ -21,7 +21,7 @@ function createSet(array) {
         );
     }
 
-    var items = typeOf(array) === "array" ? array : [];
+    var items = type(array) === "Array" ? array : [];
     var set = new Set();
 
     forEach(items, function(item) {

--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -2,10 +2,10 @@
 
 var valueToString = require("@sinonjs/commons").valueToString;
 var className = require("@sinonjs/commons").className;
-var typeOf = require("@sinonjs/commons").typeOf;
 var arrayProto = require("@sinonjs/commons").prototypes.array;
 var objectProto = require("@sinonjs/commons").prototypes.object;
 var mapForEach = require("@sinonjs/commons").prototypes.map.forEach;
+var type = require("type-detect");
 
 var getClass = require("./get-class");
 var identical = require("./identical");
@@ -111,7 +111,7 @@ function deepEqualCyclic(actual, expectation, match) {
             }
         }
 
-        if (actualObj instanceof RegExp && expectationObj instanceof RegExp) {
+        if (type(actualObj) === "RegExp" && type(expectationObj) === "RegExp") {
             if (valueToString(actualObj) !== valueToString(expectationObj)) {
                 return false;
             }
@@ -128,7 +128,7 @@ function deepEqualCyclic(actual, expectation, match) {
         var actualName = className(actualObj);
         var expectationName = className(expectationObj);
         var expectationSymbols =
-            typeOf(getOwnPropertySymbols) === "function"
+            type(getOwnPropertySymbols) === "function"
                 ? getOwnPropertySymbols(expectationObj)
                 : /* istanbul ignore next: cannot collect coverage for engine that doesn't support Symbol */
                   [];

--- a/lib/is-arguments.js
+++ b/lib/is-arguments.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var getClass = require("./get-class");
+var type = require("type-detect");
 
 /**
  * Returns `true` when `object` is an `arguments` object, `false` otherwise
@@ -10,7 +10,7 @@ var getClass = require("./get-class");
  * @returns {boolean} `true` when `object` is an `arguments` object
  */
 function isArguments(object) {
-    return getClass(object) === "Arguments";
+    return type(object) === "Arguments";
 }
 
 module.exports = isArguments;

--- a/lib/is-map.js
+++ b/lib/is-map.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var type = require("type-detect");
+
 /**
  * Returns `true` when `value` is a Map
  *
@@ -8,7 +10,7 @@
  * @private
  */
 function isMap(value) {
-    return typeof Map !== "undefined" && value instanceof Map;
+    return type(value) === "Map";
 }
 
 module.exports = isMap;

--- a/lib/is-nan.js
+++ b/lib/is-nan.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var type = require("type-detect");
+
 /**
  * Compares a `value` to `NaN`
  *
@@ -13,7 +15,7 @@ function isNaN(value) {
     // lodash
 
     // eslint-disable-next-line no-self-compare
-    return typeof value === "number" && value !== value;
+    return type(value) === "number" && value !== value;
 }
 
 module.exports = isNaN;

--- a/lib/is-object.js
+++ b/lib/is-object.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var type = require("type-detect");
+
 /**
  * Returns `true` when the value is a regular Object and not a specialized Object
  *
@@ -16,7 +18,7 @@
  */
 function isObject(value) {
     return (
-        typeof value === "object" &&
+        type(value) === "Object" &&
         value !== null &&
         // none of these are collection objects, so we can return false
         !(value instanceof Boolean) &&

--- a/lib/is-set.js
+++ b/lib/is-set.js
@@ -1,14 +1,16 @@
 "use strict";
 
+var type = require("type-detect");
+
 /**
  * Returns `true` when the argument is an instance of Set, `false` otherwise
  *
  * @alias module:samsam.isSet
- * @param  {*}  val - A value to examine
+ * @param  {*}  value - A value to examine
  * @returns {boolean} Returns `true` when the argument is an instance of Set, `false` otherwise
  */
-function isSet(val) {
-    return (typeof Set !== "undefined" && val instanceof Set) || false;
+function isSet(value) {
+    return type(value) === "Set";
 }
 
 module.exports = isSet;

--- a/lib/iterable-to-string.js
+++ b/lib/iterable-to-string.js
@@ -1,8 +1,8 @@
 "use strict";
 
 var slice = require("@sinonjs/commons").prototypes.string.slice;
-var typeOf = require("@sinonjs/commons").typeOf;
 var valueToString = require("@sinonjs/commons").valueToString;
+var type = require("type-detect");
 
 /**
  * Creates a string represenation of an iterable object
@@ -12,7 +12,7 @@ var valueToString = require("@sinonjs/commons").valueToString;
  * @returns {string}     A string representation
  */
 function iterableToString(obj) {
-    if (typeOf(obj) === "map") {
+    if (type(obj) === "Map") {
         return mapToString(obj);
     }
 
@@ -65,7 +65,7 @@ function genericIterableToString(iterable) {
  * @returns {string}      A string representation of `item`
  */
 function stringify(item) {
-    return typeof item === "string" ? "'" + item + "'" : valueToString(item);
+    return type(item) === "string" ? "'" + item + "'" : valueToString(item);
 }
 
 module.exports = iterableToString;

--- a/lib/match.js
+++ b/lib/match.js
@@ -5,7 +5,7 @@ var indexOf = require("@sinonjs/commons").prototypes.string.indexOf;
 var forEach = require("@sinonjs/commons").prototypes.array.forEach;
 var type = require("type-detect");
 
-var engineCanCompareMaps = typeof Array.from === "function";
+var engineCanCompareMaps = type(Array.from) === "function";
 var deepEqual = require("./deep-equal").use(match); // eslint-disable-line no-use-before-define
 var isArrayType = require("./is-array-type");
 var isSubset = require("./is-subset");
@@ -52,7 +52,7 @@ function arrayContains(array, subset, compare) {
  * @returns {boolean} true when `object` matches `matcherOrValue`
  */
 function match(object, matcherOrValue) {
-    if (matcherOrValue && typeof matcherOrValue.test === "function") {
+    if (matcherOrValue && type(matcherOrValue.test) === "function") {
         return matcherOrValue.test(object);
     }
 
@@ -65,7 +65,7 @@ function match(object, matcherOrValue) {
         case "function":
             return matcherOrValue(object) === true;
         case "string":
-            var notNull = typeof object === "string" || Boolean(object);
+            var notNull = type(object) === "string" || Boolean(object);
             return (
                 notNull &&
                 indexOf(
@@ -76,7 +76,7 @@ function match(object, matcherOrValue) {
         case "null":
             return object === null;
         case "undefined":
-            return typeof object === "undefined";
+            return type(object) === "undefined";
         case "Date":
             /* istanbul ignore else */
             if (type(object) === "Date") {
@@ -128,11 +128,11 @@ function match(object, matcherOrValue) {
     }
 
     /* istanbul ignore else */
-    if (matcherOrValue && typeof matcherOrValue === "object") {
+    if (matcherOrValue && type(matcherOrValue) === "Object") {
         if (matcherOrValue === object) {
             return true;
         }
-        if (typeof object !== "object") {
+        if (type(object) !== "Object") {
             return false;
         }
         var prop;
@@ -140,20 +140,20 @@ function match(object, matcherOrValue) {
         for (prop in matcherOrValue) {
             var value = object[prop];
             if (
-                typeof value === "undefined" &&
-                typeof object.getAttribute === "function"
+                type(value) === "undefined" &&
+                type(object.getAttribute) === "function"
             ) {
                 value = object.getAttribute(prop);
             }
             if (
                 matcherOrValue[prop] === null ||
-                typeof matcherOrValue[prop] === "undefined"
+                type(matcherOrValue[prop]) === "undefined"
             ) {
                 if (value !== matcherOrValue[prop]) {
                     return false;
                 }
             } else if (
-                typeof value === "undefined" ||
+                type(value) === "undefined" ||
                 !deepEqual(value, matcherOrValue[prop])
             ) {
                 return false;


### PR DESCRIPTION
Refactor to make more use of `type-detect`

❗️ This changes `samsam`s API to be compatible with `type-detect`, hence a matcher like `createMatcher.number.or(createMatcher.typeOf("set"))` should be written as `createMatcher.number.or(createMatcher.typeOf("Set"))`


<!-- mandatory -->
#### How to verify

1. Check out this branch
1. `npm ci`
1. Verify that all the tests pass
