### PR TITLE
re-introduce bound deepEqual

### DIFF
--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -24,7 +24,7 @@ var some = arrayProto.some;
 var hasOwnProperty = objectProto.hasOwnProperty;
 var objectToString = objectProto.toString;
 
-var TYPE_MAP = require("./create-matcher/type-map");
+var TYPE_MAP = require("./create-matcher/type-map")(createMatcher); // eslint-disable-line no-use-before-define
 
 /**
  * Creates a matcher object for the passed expectation

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -3,7 +3,7 @@
 var every = require("@sinonjs/commons").prototypes.array.every;
 var typeOf = require("@sinonjs/commons").typeOf;
 
-var deepEqual = require("../deep-equal");
+var deepEqualFactory = require("../deep-equal").use;
 
 var isMatcher = require("./is-matcher");
 /**
@@ -14,7 +14,8 @@ var isMatcher = require("./is-matcher");
  * @param {object} expectation An object with properties to match on
  * @returns {boolean} Returns true when `actual` matches all properties in `expectation`
  */
-function matchObject(actual, expectation) {
+function matchObject(actual, expectation, matcher) {
+    var deepEqual = deepEqualFactory(matcher);
     if (actual === null || actual === undefined) {
         return false;
     }

--- a/lib/create-matcher/type-map.js
+++ b/lib/create-matcher/type-map.js
@@ -8,53 +8,55 @@ var valueToString = require("@sinonjs/commons").valueToString;
 
 var matchObject = require("./match-object");
 
-var TYPE_MAP = {
-    function: function(m, expectation, message) {
-        m.test = expectation;
-        m.message = message || "match(" + functionName(expectation) + ")";
-    },
-    number: function(m, expectation) {
-        m.test = function(actual) {
-            // we need type coercion here
-            return expectation == actual; // eslint-disable-line eqeqeq
-        };
-    },
-    object: function(m, expectation) {
-        var array = [];
-
-        if (typeof expectation.test === "function") {
+var TYPE_MAP = function(match) {
+    return {
+        function: function(m, expectation, message) {
+            m.test = expectation;
+            m.message = message || "match(" + functionName(expectation) + ")";
+        },
+        number: function(m, expectation) {
             m.test = function(actual) {
-                return expectation.test(actual) === true;
+                // we need type coercion here
+                return expectation == actual; // eslint-disable-line eqeqeq
             };
-            m.message = "match(" + functionName(expectation.test) + ")";
+        },
+        object: function(m, expectation) {
+            var array = [];
+
+            if (typeof expectation.test === "function") {
+                m.test = function(actual) {
+                    return expectation.test(actual) === true;
+                };
+                m.message = "match(" + functionName(expectation.test) + ")";
+                return m;
+            }
+
+            array = map(Object.keys(expectation), function(key) {
+                return key + ": " + valueToString(expectation[key]);
+            });
+
+            m.test = function(actual) {
+                return matchObject(actual, expectation, match);
+            };
+            m.message = "match(" + join(array, ", ") + ")";
+
             return m;
+        },
+        regexp: function(m, expectation) {
+            m.test = function(actual) {
+                return typeof actual === "string" && expectation.test(actual);
+            };
+        },
+        string: function(m, expectation) {
+            m.test = function(actual) {
+                return (
+                    typeof actual === "string" &&
+                    stringIndexOf(actual, expectation) !== -1
+                );
+            };
+            m.message = 'match("' + expectation + '")';
         }
-
-        array = map(Object.keys(expectation), function(key) {
-            return key + ": " + valueToString(expectation[key]);
-        });
-
-        m.test = function(actual) {
-            return matchObject(actual, expectation);
-        };
-        m.message = "match(" + join(array, ", ") + ")";
-
-        return m;
-    },
-    regexp: function(m, expectation) {
-        m.test = function(actual) {
-            return typeof actual === "string" && expectation.test(actual);
-        };
-    },
-    string: function(m, expectation) {
-        m.test = function(actual) {
-            return (
-                typeof actual === "string" &&
-                stringIndexOf(actual, expectation) !== -1
-            );
-        };
-        m.message = 'match("' + expectation + '")';
-    }
+    };
 };
 
 module.exports = TYPE_MAP;

--- a/lib/create-matcher/type-map.js
+++ b/lib/create-matcher/type-map.js
@@ -8,7 +8,7 @@ var valueToString = require("@sinonjs/commons").valueToString;
 
 var matchObject = require("./match-object");
 
-var TYPE_MAP = function(match) {
+var createTypeMap = function(match) {
     return {
         function: function(m, expectation, message) {
             m.test = expectation;
@@ -59,4 +59,4 @@ var TYPE_MAP = function(match) {
     };
 };
 
-module.exports = TYPE_MAP;
+module.exports = createTypeMap;

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -877,8 +877,14 @@ describe("deepEqual", function() {
         describe("with complex content", function() {
             it("returns true if nested matcher inside array", function() {
                 var checkDeep = samsam.deepEqual(
-                    {prop: [function() {}]},
-                    samsam.createMatcher({prop: [samsam.match.func]})
+                    {
+                        prop: [
+                            function() {
+                                return;
+                            }
+                        ]
+                    },
+                    samsam.createMatcher({ prop: [samsam.match.func] })
                 );
                 assert.isTrue(checkDeep);
             });

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -875,6 +875,14 @@ describe("deepEqual", function() {
         });
 
         describe("with complex content", function() {
+            it("returns true if nested matcher inside array", function() {
+                var checkDeep = samsam.deepEqual(
+                    {prop: [function() {}]},
+                    samsam.createMatcher({prop: [samsam.match.func]})
+                );
+                assert.isTrue(checkDeep);
+            });
+
             it("returns true if arrays", function() {
                 var checkDeep = samsam.deepEqual(
                     [1, 2, "Hey there", func, { id: 42, prop: [2, 3] }],


### PR DESCRIPTION
During fd5e59e8, we lost our bound deepEqual (`deepEqual.use(createMatcher)`) and ended up with a regular, unbound matcher-less one (`deepEqual`).

This means situations like the following have no matcher as they recur:

```
deepEqual(
  {foo: [() => {}]},
  match({foo: [match.func]})
)
```

Fixes sinonjs/sinon#2183 too

---

While this does in fact fix the issue, i'm not 100% happy with it.

Since these matchers were extracted, we're on the very edge of slipping into circular-dependency hell. In reality, those extracted matchers need their `deepEqual` bound to `createMatcher`, but `createMatcher` is what included them! So we can't (hence why i pass it through the type map factory in this PR).

What i suggest is you have a good think of why you have this `use(...)` function at all. Why would you ever want a deepequal which has no matcher/context? Maybe a refactor is needed to clean things up and drop that concept? So the standard deepEqual just works.