### PR TITLE
Fix issue with nested array matching

### DIFF
--- a/lib/create-matcher.test.js
+++ b/lib/create-matcher.test.js
@@ -1523,5 +1523,29 @@ describe("matcher", function() {
 
             assert.isTrue(match.test([{ str: "sinon", foo: "bar" }]));
         });
+
+        it("returns true for an object containing a matching array of nested matchers", function() {
+            var match = createMatcher({
+                deep: { nested: [createMatcher({ partial: "yes" })] }
+            });
+
+            assert.isTrue(
+                match.test({
+                    deep: { nested: [{ partial: "yes", other: "ok" }] }
+                })
+            );
+        });
+
+        it("returns false for an object containing a non matching array of nested matchers", function() {
+            var match = createMatcher({
+                deep: { nested: [createMatcher({ partial: "no" })] }
+            });
+
+            assert.isFalse(
+                match.test({
+                    deep: { nested: [{ partial: "yes", other: "ok" }] }
+                })
+            );
+        });
     });
 });

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -29,7 +29,7 @@ function matchObject(actual, expectation, matcher) {
                 return false;
             }
         } else if (typeOf(exp) === "object") {
-            if (!matchObject(act, exp)) {
+            if (!matchObject(act, exp, matcher)) {
                 return false;
             }
         } else if (!deepEqual(act, exp)) {


### PR DESCRIPTION
The reintroduction of deepEqual in #160 missed a function argument when recursively calling matchObject so that any deepEquals were unable to evaluate custom matchers because matcher === undefined. 

#### Solution
This PR adds the missing function argument and a test to verify that it's working

#### How to verify

1. Check out this branch
2. `npm ci`
3. remove the fix and see that the new test fails to match properly