### PR TITLE
Evaluate symbol keys for object matchers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -354,7 +354,9 @@ If the matcher does not have a test method, a recursive match is performed. If
 all properties of `matcher` matches corresponding properties in `object`,
 `match` returns `true`. Note that the object matcher does not care if the
 number of properties in the two objects are the same - only if all properties in
-the matcher recursively matches ones in `object`.
+the matcher recursively matches ones in `object`. If supported, this object matchers
+include [symbolic properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
+in the comparison.
 
 ```javascript
 // true

--- a/lib/create-matcher.test.js
+++ b/lib/create-matcher.test.js
@@ -311,6 +311,20 @@ describe("matcher", function() {
         }
     });
 
+    it("returns true for Symbol key", function() {
+        if (typeof Symbol === "function") {
+            var symbol = Symbol();
+            var actual = { quux: "baz" };
+            var expected = {};
+            actual[symbol] = "foo";
+            expected[symbol] = "foo";
+
+            var match = createMatcher(expected);
+
+            assert(match.test(actual));
+        }
+    });
+
     it("returns false for Symbol key mismatch", function() {
         if (typeof Symbol === "function") {
             var symbol = Symbol();

--- a/lib/create-matcher.test.js
+++ b/lib/create-matcher.test.js
@@ -314,10 +314,14 @@ describe("matcher", function() {
     it("returns false for Symbol key mistmatch", function() {
         if (typeof Symbol === "function") {
             var symbol = Symbol();
+            var actual = {};
+            var expected = {};
+            actual[symbol] = "foo";
+            expected[symbol] = "bar";
 
-            var match = createMatcher({ [symbol]: "foo" });
+            var match = createMatcher(expected);
 
-            assert.isFalse(match.test({ [symbol]: "bar" }));
+            assert.isFalse(match.test(actual));
         }
     });
 

--- a/lib/create-matcher.test.js
+++ b/lib/create-matcher.test.js
@@ -311,7 +311,7 @@ describe("matcher", function() {
         }
     });
 
-    it("returns false for Symbol key mistmatch", function() {
+    it("returns false for Symbol key mismatch", function() {
         if (typeof Symbol === "function") {
             var symbol = Symbol();
             var actual = {};

--- a/lib/create-matcher.test.js
+++ b/lib/create-matcher.test.js
@@ -311,6 +311,16 @@ describe("matcher", function() {
         }
     });
 
+    it("returns false for Symbol key mistmatch", function() {
+        if (typeof Symbol === "function") {
+            var symbol = Symbol();
+
+            var match = createMatcher({ [symbol]: "foo" });
+
+            assert.isFalse(match.test({ [symbol]: "bar" }));
+        }
+    });
+
     it("returns true if test function in object returns true", function() {
         var match = createMatcher({
             test: function() {

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -2,6 +2,8 @@
 
 var every = require("@sinonjs/commons").prototypes.array.every;
 var typeOf = require("@sinonjs/commons").typeOf;
+var keys = Object.keys;
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
 
 var deepEqualFactory = require("../deep-equal").use;
 
@@ -21,12 +23,12 @@ function matchObject(actual, expectation, matcher) {
         return false;
     }
 
-    var keys = Object.keys(expectation)
-    if(typeof Object.getOwnPropertySymbols === "function") {
-        keys = keys.concat(Object.getOwnPropertySymbols(expectation))
+    var expectedKeys = keys(expectation)
+    if(typeof getOwnPropertySymbols === "function") {
+        expectedKeys = expectedKeys.concat(getOwnPropertySymbols(expectation))
     }
 
-    return every(keys, function(key) {
+    return every(expectedKeys, function(key) {
         var exp = expectation[key];
         var act = actual[key];
 

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -21,7 +21,12 @@ function matchObject(actual, expectation, matcher) {
         return false;
     }
 
-    return every(Object.keys(expectation), function(key) {
+    var keys = Object.keys(expectation)
+    if(typeof Object.getOwnPropertySymbols === "function") {
+        keys = keys.concat(Object.getOwnPropertySymbols(expectation))
+    }
+
+    return every(keys, function(key) {
         var exp = expectation[key];
         var act = actual[key];
 

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -2,12 +2,15 @@
 
 var every = require("@sinonjs/commons").prototypes.array.every;
 var typeOf = require("@sinonjs/commons").typeOf;
-var keys = Object.keys;
-var getOwnPropertySymbols = Object.getOwnPropertySymbols;
 
 var deepEqualFactory = require("../deep-equal").use;
 
 var isMatcher = require("./is-matcher");
+
+var keys = Object.keys;
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var concat = Array.prototype.concat;
+
 /**
  * Matches `actual` with `expectation`
  *
@@ -23,9 +26,9 @@ function matchObject(actual, expectation, matcher) {
         return false;
     }
 
-    var expectedKeys = keys(expectation)
-    if(typeof getOwnPropertySymbols === "function") {
-        expectedKeys = expectedKeys.concat(getOwnPropertySymbols(expectation))
+    var expectedKeys = keys(expectation);
+    if (typeof getOwnPropertySymbols === "function") {
+        expectedKeys = concat.call(expectedKeys, getOwnPropertySymbols(expectation));
     }
 
     return every(expectedKeys, function(key) {

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -27,7 +27,8 @@ function matchObject(actual, expectation, matcher) {
     }
 
     var expectedKeys = keys(expectation);
-    if (typeof getOwnPropertySymbols === "function") {
+    /* istanbul ignore else: cannot collect coverage for engine that doesn't support Symbol */
+    if (typeOf(getOwnPropertySymbols) === "function") {
         expectedKeys = concat(expectedKeys, getOwnPropertySymbols(expectation));
     }
 

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -28,7 +28,10 @@ function matchObject(actual, expectation, matcher) {
 
     var expectedKeys = keys(expectation);
     if (typeof getOwnPropertySymbols === "function") {
-        expectedKeys = concat.call(expectedKeys, getOwnPropertySymbols(expectation));
+        expectedKeys = concat.call(
+            expectedKeys,
+            getOwnPropertySymbols(expectation)
+        );
     }
 
     return every(expectedKeys, function(key) {

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var every = require("@sinonjs/commons").prototypes.array.every;
+var concat = require("@sinonjs/commons").prototypes.array.concat;
 var typeOf = require("@sinonjs/commons").typeOf;
 
 var deepEqualFactory = require("../deep-equal").use;
@@ -9,7 +10,6 @@ var isMatcher = require("./is-matcher");
 
 var keys = Object.keys;
 var getOwnPropertySymbols = Object.getOwnPropertySymbols;
-var concat = Array.prototype.concat;
 
 /**
  * Matches `actual` with `expectation`
@@ -28,7 +28,7 @@ function matchObject(actual, expectation, matcher) {
 
     var expectedKeys = keys(expectation);
     if (typeof getOwnPropertySymbols === "function") {
-        expectedKeys = concat.call(
+        expectedKeys = concat(
             expectedKeys,
             getOwnPropertySymbols(expectation)
         );

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -28,10 +28,7 @@ function matchObject(actual, expectation, matcher) {
 
     var expectedKeys = keys(expectation);
     if (typeof getOwnPropertySymbols === "function") {
-        expectedKeys = concat(
-            expectedKeys,
-            getOwnPropertySymbols(expectation)
-        );
+        expectedKeys = concat(expectedKeys, getOwnPropertySymbols(expectation));
     }
 
     return every(expectedKeys, function(key) {


### PR DESCRIPTION
Updates the behavior of `match()` with objects so that it takes symbolic properties into account. Currently symbolic properties are ignored altogether for the purposes of matching.


#### Background
This is a similar fix to #64, and extends that fix to the usage of `match()` with objects. It in fact borrows from that PR.

I ran into this when attempting to verify that my code was generating the correct queries with Sequelize after upgrading to the latest version, which uses Symbol keys extensively, using a set of symbols that are properties of the `Op` object for various query operations. My code was something like:

```
const findAllStub = Sinon.stub(User, "findAll")
User.findAll({
  where: {
    firstName: "John",
    lastName: {
      [Op.iLike]: "%son"
    }
  },
  offset: 10,
  limit: 20
})
assert(findAllStub.calledWith(match({where: { lastName: { [Op.iLike]: "%son" } } }))
```
Which passed, but we found that this also passed:
```
assert(findAllStub.calledWith(match({where: { lastName: { [Op.iLike]: "bananas" } } }))
```

Upon investigation, symbolic properties were being simply ignored for the sake of comparison in matchers. I found #64 which addressed this issue for deep equality, so I based this patch on the methodology used there.


#### Solution
When iterating over properties to compare in `matchObject()`, if `Object.getOwnPropertySymbols()` is defined it uses it to add those keys into the list to be iterated over in addition to those returned by `Object.keys()`, so that symbolic properties are accounted for in the comparison.

I also cached the standard library functions as was requested in #64, I'm not sure if that's still desired. Easy to revert those commits if not.

#### How to verify

1. Check out this branch
1. `npm ci`
1. Run tests. This PR adds a test for a symbol key mismatch.
