### PR TITLE
Add match.json

### DIFF
--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -187,6 +187,30 @@ createMatcher.hasNested = function(property, value) {
     }, message);
 };
 
+var jsonParseResultTypes = {
+    null: true,
+    boolean: true,
+    number: true,
+    string: true,
+    object: true,
+    array: true
+};
+createMatcher.json = function(value) {
+    if (!jsonParseResultTypes[typeOf(value)]) {
+        throw new TypeError("Value cannot be the result of JSON.parse");
+    }
+    var message = "json(" + JSON.stringify(value, null, "  ") + ")";
+    return createMatcher(function(actual) {
+        var parsed;
+        try {
+            parsed = JSON.parse(actual);
+        } catch (e) {
+            return false;
+        }
+        return deepEqual(parsed, value);
+    }, message);
+};
+
 createMatcher.every = function(predicate) {
     assertMatcher(predicate);
 

--- a/lib/create-matcher.test.js
+++ b/lib/create-matcher.test.js
@@ -689,6 +689,130 @@ describe("matcher", function() {
         })
     );
 
+    describe(".json", function() {
+        it("throws if argument cannot be the result of JSON.parse", function() {
+            assert.exception(
+                function() {
+                    createMatcher.json();
+                },
+                { name: "TypeError" }
+            );
+            assert.exception(
+                function() {
+                    // eslint-disable-next-line no-empty-function
+                    createMatcher.json(function() {});
+                },
+                { name: "TypeError" }
+            );
+            if (typeof Symbol !== "undefined") {
+                assert.exception(
+                    function() {
+                        createMatcher.json(Symbol());
+                    },
+                    { name: "TypeError" }
+                );
+            }
+        });
+
+        it("returns matcher", function() {
+            var json = createMatcher.json({});
+
+            assert(createMatcher.isMatcher(json));
+        });
+
+        it("returns false if actual cannot be parsed", function() {
+            var json = createMatcher.json(null);
+            var result;
+
+            refute.exception(function() {
+                result = json.test("not json");
+            });
+            assert.isFalse(result);
+        });
+
+        it("returns true for null match", function() {
+            assert(createMatcher.json(null).test("null"));
+        });
+
+        it("returns false for null mismatch", function() {
+            assert.isFalse(createMatcher.json(null).test("false"));
+            assert.isFalse(createMatcher.json(null).test('""'));
+        });
+
+        it("returns true for boolean match", function() {
+            assert(createMatcher.json(true).test("true"));
+            assert(createMatcher.json(false).test("false"));
+        });
+
+        it("returns false for boolean mismatch", function() {
+            assert.isFalse(createMatcher.json(false).test("true"));
+            assert.isFalse(createMatcher.json(true).test("false"));
+            assert.isFalse(createMatcher.json(true).test("1"));
+            assert.isFalse(createMatcher.json(false).test("null"));
+        });
+
+        it("returns true for number match", function() {
+            assert(createMatcher.json(0).test("0"));
+            assert(createMatcher.json(1).test("1"));
+        });
+
+        it("returns false for number mismatch", function() {
+            assert.isFalse(createMatcher.json(0).test("1"));
+            assert.isFalse(createMatcher.json(1).test("0"));
+            assert.isFalse(createMatcher.json(0).test("null"));
+            assert.isFalse(createMatcher.json(0).test("false"));
+        });
+
+        it("returns true for string match", function() {
+            assert(createMatcher.json("").test('""'));
+            assert(createMatcher.json("test").test('"test"'));
+        });
+
+        it("returns false for string mismatch", function() {
+            assert.isFalse(createMatcher.json("").test('"test"'));
+            assert.isFalse(createMatcher.json("test").test('"tes"'));
+            assert.isFalse(createMatcher.json("1").test("1"));
+            assert.isFalse(createMatcher.json("true").test("true"));
+        });
+
+        it("returns true for object match", function() {
+            assert(createMatcher.json({}).test("{}"));
+            assert(
+                createMatcher
+                    .json({ foo: 1, bar: "yes" })
+                    .test(JSON.stringify({ bar: "yes", foo: 1 }))
+            );
+        });
+
+        it("returns false for object mismatch", function() {
+            assert.isFalse(createMatcher.json({ foo: 1 }).test("{}"));
+            assert.isFalse(
+                createMatcher.json({}).test(JSON.stringify({ foo: 1 }))
+            );
+        });
+
+        it("returns true for array match", function() {
+            assert(createMatcher.json([]).test("[]"));
+            assert(
+                createMatcher.json([1, "yes"]).test(JSON.stringify([1, "yes"]))
+            );
+        });
+
+        it("returns false for array mismatch", function() {
+            assert.isFalse(createMatcher.json([1]).test("[]"));
+            assert.isFalse(createMatcher.json([]).test("[1]"));
+            assert.isFalse(createMatcher.json([1, 2]).test("[2, 1]"));
+        });
+
+        it('wraps the given value with "json()"', function() {
+            assert.equals(createMatcher.json(null).toString(), "json(null)");
+            assert.equals(
+                createMatcher.json({ foo: "bar" }).toString(),
+                'json({\n  "foo": "bar"\n})'
+            );
+        });
+    });
+
     describe(".hasSpecial", function() {
         it("returns true if object has inherited property", function() {
             var has = createMatcher.has("toString");


### PR DESCRIPTION
### Add `match.json(value)` to the matchers

While we have `assert.json` in `referee`, I'd like to add `match.json` for use cases like these:

```js
// referee
assert.equals(request, {
  header: {},
  body: match.json({ some: 'value' })
});

// sinon
sinon.assert.calledOnceWith(callback, null, match.json({ some: 'value' }));
```

<!-- mandatory -->
#### How to verify

1. Check out this branch
2. `npm ci`
3. `npm test`
