### PR TITLE
Fix deep equal comparison between promises

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -12,6 +12,7 @@ globals:
   Set: false
   Symbol: false
   BigInt: false
+  Promise: false
   Int8Array: false
   Uint8Array: false
   Uint8ClampedArray: false

--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -117,6 +117,10 @@ function deepEqualCyclic(actual, expectation, match) {
             }
         }
 
+        if (actualObj instanceof Promise && expectationObj instanceof Promise) {
+            return actualObj === expectationObj;
+        }
+
         if (actualObj instanceof Error && expectationObj instanceof Error) {
             return actualObj === expectationObj;
         }

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -903,4 +903,19 @@ describe("deepEqual", function () {
             });
         });
     });
+
+    describe("promises", function () {
+        it("returns true if the same promise instance is compared", function () {
+            var promise = Promise.resolve();
+            var checkDeep = samsam.deepEqual(promise, promise);
+            assert.isTrue(checkDeep);
+        });
+
+        it("returns false if a different promise instance is compared", function () {
+            var promise1 = Promise.resolve();
+            var promise2 = Promise.resolve();
+            var checkDeep = samsam.deepEqual(promise1, promise2);
+            assert.isFalse(checkDeep);
+        });
+    });
 });


### PR DESCRIPTION
<!-- Summary - mandatory
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Fix issue #216 by explicitly checking Promise instances

<!-- (Problem in detail) - optional -->

#### Background

I found that sinon spy `calledWith` does not properly check promises equality and always returns true.
Reported [here](https://github.com/sinonjs/sinon/issues/2345)

#### Solution

Simple fix, I've just added explicit Promise instance checking similar to how `Error` or `RegExp` are checked. I've also added a couple tests to verify it. I haven't added a test to check promises against other type of data as that was already working but I can add a explicit test for that case if you want.

#### How to verify

1. Check out this branch
1. `npm t` (or just check the ci)

