### PR TITLE
Add support for iterables

### DIFF
--- a/lib/create-matcher.test.js
+++ b/lib/create-matcher.test.js
@@ -159,6 +159,41 @@ describe("matcher", function () {
         assert.isFalse(match.test([{ str: "sinon", ignored: "value" }]));
     });
 
+    it("returns true if set iterator is equal", function () {
+        var match = createMatcher(new Set(["a", "b"]).values());
+
+        assert(match.test(new Set(["a", "b"]).values()));
+    });
+
+    it("returns false if set iterator is not equal", function () {
+        var match = createMatcher(new Set(["a", "b"]).values());
+
+        assert.isFalse(match.test(new Set(["a", "b", "c"]).values()));
+    });
+
+    it("returns true if map iterator is equal", function () {
+        var map = new Map();
+        map.set("a", 1);
+        map.set("b", 2);
+
+        var match = createMatcher(map.values());
+        assert(match.test(map.values()));
+    });
+
+    it("returns false if map iterator is not equal", function () {
+        var map = new Map();
+        map.set("a", 1);
+        map.set("b", 2);
+
+        var wrongMap = new Map();
+        wrongMap.set("a", 1);
+        wrongMap.set("b", 2);
+        wrongMap.set("c", 3);
+
+        var match = createMatcher(map.values());
+        assert.isFalse(match.test(wrongMap.values()));
+    });
+
     it("returns true if number objects are equal", function () {
         /*eslint-disable no-new-wrappers*/
         var match = createMatcher({ one: new Number(1) });

--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -10,8 +10,10 @@ var mapForEach = require("@sinonjs/commons").prototypes.map.forEach;
 var getClass = require("./get-class");
 var identical = require("./identical");
 var isArguments = require("./is-arguments");
+var isArrayType = require("./is-array-type");
 var isDate = require("./is-date");
 var isElement = require("./is-element");
+var isIterable = require("./is-iterable");
 var isMap = require("./is-map");
 var isNaN = require("./is-nan");
 var isObject = require("./is-object");
@@ -187,6 +189,35 @@ function deepEqualCyclic(actual, expectation, match) {
             });
 
             return mapsDeeplyEqual;
+        }
+
+        var isActualNonArrayIterable =
+            isIterable(actualObj) &&
+            !isArrayType(actualObj) &&
+            !isArguments(actualObj);
+        var isExpectationNonArrayIterable =
+            isIterable(expectation) &&
+            !isArrayType(expectation) &&
+            !isArguments(expectation);
+        if (isActualNonArrayIterable || isExpectationNonArrayIterable) {
+            if (!isActualNonArrayIterable || !isExpectationNonArrayIterable) {
+                return false;
+            }
+
+            var actualArray = Array.from(actualObj);
+            var expectationArray = Array.from(expectation);
+            if (actualArray.length !== expectationArray.length) {
+                return false;
+            }
+
+            var arrayDeeplyEquals = true;
+            every(actualArray, function (key) {
+                arrayDeeplyEquals =
+                    arrayDeeplyEquals &&
+                    deepEqualCyclic(actualArray[key], expectationArray[key]);
+            });
+
+            return arrayDeeplyEquals;
         }
 
         return every(expectationKeysAndSymbols, function (key) {

--- a/lib/is-iterable.js
+++ b/lib/is-iterable.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/**
+ * Returns `true` when the argument is an iterable, `false` otherwise
+ *
+ * @alias module:samsam.isIterable
+ * @param  {*}  val - A value to examine
+ * @returns {boolean} Returns `true` when the argument is an iterable, `false` otherwise
+ */
+function isIterable(val) {
+    // checks for null and undefined
+    if (typeof val !== "object") {
+        return false;
+    }
+    return typeof val[Symbol.iterator] === "function";
+}
+
+module.exports = isIterable;


### PR DESCRIPTION
Fix issue https://github.com/sinonjs/sinon/issues/2400 by adding support for iterables.

#### Background

The matchers currently don't account for Map and Set iterables. This was originally discovered in the issue linked above.

#### Solution

- I add a check for non-Array, non-Arguments iterables in the function. At this point primitive values are already handled.
- I transform both iterables to Arrays. I noticed that deep browser support is really important in this repo, so open to approaches on how folks want to do this. One idea I had was to polyfill `Array.from` using the recommendation from MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#polyfill
- This should also support deeply nested iterables

#### Testing

The tests describe a good process for trying to both reproduce the original issue as well as manually verifying that this approach works.