### PR TITLE
Fix to compare input for iteratables.

### DIFF
--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -196,12 +196,12 @@ function deepEqualCyclic(actual, expectation, match) {
             !isArrayType(actualObj) &&
             !isArguments(actualObj);
         var isExpectationNonArrayIterable =
-            isIterable(expectation) &&
-            !isArrayType(expectation) &&
-            !isArguments(expectation);
+            isIterable(expectationObj) &&
+            !isArrayType(expectationObj) &&
+            !isArguments(expectationObj);
         if (isActualNonArrayIterable || isExpectationNonArrayIterable) {
             var actualArray = Array.from(actualObj);
-            var expectationArray = Array.from(expectation);
+            var expectationArray = Array.from(expectationObj);
             if (actualArray.length !== expectationArray.length) {
                 return false;
             }

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -926,35 +926,45 @@ describe("deepEqual", function () {
     });
 
     describe("nested iterable", function () {
-        class Foo {
-            constructor(size = 0) {
-                // eslint-disable-next-line mocha/no-setup-in-describe
-                this.size = size;
+        let buildInstance;
+
+        before(function () {
+            class Foo {
+                constructor(size = 0) {
+                    this.size = size;
+                }
             }
-        }
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        Foo.prototype[Symbol.iterator] = function () {
-            var count = 1;
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            var size = this.size;
-            return {
-                next: function () {
-                    return count <= size
-                        ? { value: count++, done: false }
-                        : { value: undefined, done: true };
-                },
+            Foo.prototype[Symbol.iterator] = function () {
+                var count = 1;
+                var size = this.size;
+                return {
+                    next: function () {
+                        return count <= size
+                            ? { value: count++, done: false }
+                            : { value: undefined, done: true };
+                    },
+                };
             };
-        };
+            buildInstance = function (size) {
+                return new Foo(size);
+            };
+        });
 
         it("return true if same size", function () {
             assert.isTrue(
-                samsam.deepEqual({ a: new Foo(2) }, { a: new Foo(2) })
+                samsam.deepEqual(
+                    { a: buildInstance(2) },
+                    { a: buildInstance(2) }
+                )
             );
         });
 
         it("return false if different size", function () {
             assert.isFalse(
-                samsam.deepEqual({ a: new Foo(2) }, { a: new Foo(3) })
+                samsam.deepEqual(
+                    { a: buildInstance(2) },
+                    { a: buildInstance(3) }
+                )
             );
         });
     });

--- a/lib/deep-equal.test.js
+++ b/lib/deep-equal.test.js
@@ -924,4 +924,38 @@ describe("deepEqual", function () {
             assert.isFalse(checkDeep);
         });
     });
+
+    describe("nested iterable", function () {
+        class Foo {
+            constructor(size = 0) {
+                // eslint-disable-next-line mocha/no-setup-in-describe
+                this.size = size;
+            }
+        }
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        Foo.prototype[Symbol.iterator] = function () {
+            var count = 1;
+            // eslint-disable-next-line mocha/no-setup-in-describe
+            var size = this.size;
+            return {
+                next: function () {
+                    return count <= size
+                        ? { value: count++, done: false }
+                        : { value: undefined, done: true };
+                },
+            };
+        };
+
+        it("return true if same size", function () {
+            assert.isTrue(
+                samsam.deepEqual({ a: new Foo(2) }, { a: new Foo(2) })
+            );
+        });
+
+        it("return false if different size", function () {
+            assert.isFalse(
+                samsam.deepEqual({ a: new Foo(2) }, { a: new Foo(3) })
+            );
+        });
+    });
 });


### PR DESCRIPTION
<!-- Summary - mandatory
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Fix input's which add by PR #225 


<!-- (Problem in detail) - optional -->

#### Background

<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!-- (Solution in detail) - optional -->
Does not match when using [immutable.js](https://immutable-js.com/) such as the following
```js
assert.isTrue(samsam.deepEqual(
  { a: immutable.fromJS({ 'foo': 'bar', 'baz': [1] }) },
  { a: immutable.fromJS({ 'foo': 'bar', 'baz': [1] }) }
));
```
Before #225, it matches.

#### Solution

<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

<!-- mandatory -->
Fix to compare same nest.
#### How to verify

1. Check out this branch
1. `npm ci`
1. `npm test`
