### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: Node CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Restrict the GitHub token permissions only to the required ones; this
way, even if the attackers will succeed in compromising your workflow,
they won’t be able to do much.

Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests

See sinonjs/sinon#2461