### PR TITLE
Fix #237: compare jQuery objects

### DIFF
--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -191,6 +191,19 @@ function deepEqualCyclic(actual, expectation, match) {
             return mapsDeeplyEqual;
         }
 
+        // jQuery objects have iteration protocols
+        // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
+        // But, they don't work well with the implementation concerning iterables below,
+        // so we will detect them and use jQuery's own equality function
+        /* istanbul ignore next -- this can only be tested in the `test-headless` script */
+        if (
+            actualObj.constructor &&
+            actualObj.constructor.name === "jQuery" &&
+            typeof actualObj.is === "function"
+        ) {
+            return actualObj.is(expectationObj);
+        }
+
         var isActualNonArrayIterable =
             isIterable(actualObj) &&
             !isArrayType(actualObj) &&

--- a/lib/issues.test.js
+++ b/lib/issues.test.js
@@ -24,8 +24,15 @@ describe("issues", function () {
 
         context("when comparing different jQuery objects", function () {
             it("should return false", function () {
+                jQuery(`
+                    <body>
+                        <p id='test1'>My <em>old</em> text</p>
+                        <p id='test2'>My <em>new</em> text</p>
+                    </body>
+                `).appendTo("html");
+
                 assert.isFalse(
-                    samsam.deepEqual(jQuery("head"), jQuery("body"))
+                    samsam.deepEqual(jQuery("#test1"), jQuery("#test2"))
                 );
             });
         });


### PR DESCRIPTION
This PR contains a fix for #237 

#### How to observe issue

1. `git checkout 57756a9efad21bedf07420efd1e3b3be0d7ae09a` (latest commit on `main`)
2. `npm ci`
3. `npm run test-headless`
4. Observe one test failing

#### How to verify

1. Check out this branch
5. `npm ci`
6. `npm run test-headless`
7. Observe all tests pass