### PR TITLE
Drop Node 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18, 19]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR drops support for Node 12 and adds support for 18 and 19.

See: https://github.com/nodejs/release#release-schedule