### PR TITLE
Fix matcher cyclic object infinite recursion issue

### DIFF
--- a/lib/create-matcher.test.js
+++ b/lib/create-matcher.test.js
@@ -129,6 +129,14 @@ describe("matcher", function () {
         assert(match.test({ deep: { str: "sinon", ignored: "value" } }));
     });
 
+    it("returns true for partial matching cyclic object", function () {
+        var cyclicObj = { a: null };
+        cyclicObj.a = cyclicObj;
+        var match = createMatcher({ b: cyclicObj });
+
+        assert(match.test({ b: cyclicObj, c: "c" }));
+    });
+
     it("returns false if a property is not equal", function () {
         var match = createMatcher({ str: "sinon", nr: 1 });
 

--- a/lib/create-matcher/match-object.js
+++ b/lib/create-matcher/match-object.js
@@ -6,6 +6,7 @@ var typeOf = require("@sinonjs/commons").typeOf;
 
 var deepEqualFactory = require("../deep-equal").use;
 
+var identical = require("../identical");
 var isMatcher = require("./is-matcher");
 
 var keys = Object.keys;
@@ -41,6 +42,9 @@ function matchObject(actual, expectation, matcher) {
                 return false;
             }
         } else if (typeOf(exp) === "object") {
+            if (identical(exp, act)) {
+                return true;
+            }
             if (!matchObject(act, exp, matcher)) {
                 return false;
             }


### PR DESCRIPTION
Fix https://github.com/sinonjs/samsam/issues/233, adding a test case to verify

#### Solution

As the issue suggested, I've added an `identical()` check to exit the recursion if the expected and actual values of a key are identical objects (this catches circular objects and prevents calling back into `matchObject` infinitely).

#### How to verify

TDD: new test causes a maximum call stack recursion error without the fix, passes with the fix. Rest of test suite passes.