### PR TITLE
Remove dependency on the deprecated lodash.get

### DIFF
--- a/lib/create-matcher.js
+++ b/lib/create-matcher.js
@@ -4,7 +4,6 @@ var arrayProto = require("@sinonjs/commons").prototypes.array;
 var deepEqual = require("./deep-equal").use(createMatcher); // eslint-disable-line no-use-before-define
 var every = require("@sinonjs/commons").every;
 var functionName = require("@sinonjs/commons").functionName;
-var get = require("lodash.get");
 var iterableToString = require("./iterable-to-string");
 var objectProto = require("@sinonjs/commons").prototypes.object;
 var typeOf = require("@sinonjs/commons").typeOf;
@@ -192,14 +191,15 @@ createMatcher.hasNested = function (property, value) {
     }
     message += ")";
     return createMatcher(function (actual) {
-        if (
-            actual === undefined ||
-            actual === null ||
-            get(actual, property) === undefined
-        ) {
-            return false;
+        const parts = property.split(/(?:\.|\[|\])+?/).filter(Boolean);
+        let current = actual;
+        for (const part of parts) {
+            current = current?.[part];
+            if (current === undefined) {
+                return false;
+            }
         }
-        return onlyProperty || deepEqual(get(actual, property), value);
+        return onlyProperty || deepEqual(current, value);
     }, message);
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "lodash.get": "^4.4.2",
         "type-detect": "^4.1.0"
       },
       "devDependencies": {
@@ -5253,7 +5252,8 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
@@ -13189,7 +13189,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   ],
   "dependencies": {
     "@sinonjs/commons": "^3.0.1",
-    "lodash.get": "^4.4.2",
     "type-detect": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
lodash.get has been deprecated and consumers of samsam get the following deprecation warning during their npm install:

> npm warn deprecated lodash.get@4.4.2: This package is deprecated. Use the optional chaining (?.) operator instead.

#### Background

Fixes issue: https://github.com/sinonjs/samsam/issues/253


<!-- mandatory -->

#### How to verify

1. Check out this branch
2. `npm ci`
3. `npm run test`
