### PR TITLE
fix: ignore coverage for mochify.webdriver.cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
       "dist/**",
       "eslint-local-rules.js",
       "lib/deep-equal-benchmark.js",
+      "mochify.webdriver.cjs",
       "out/**",
       "rollup.config.js",
       "site/**",


### PR DESCRIPTION
#### Background

mochify.webdriver.cjs is used to setup testing of samsam, and hence doesn't have unit tests.  The code coverage jobs/scripts fail currently.

#### Solution

We can exclude mochify.webdriver.cjs from code coverage

#### How to verify

Github workflow check for this PR
