### PR TITLE
ci: adjust dependabot config and code coverage upload

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,18 +6,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
-      time: "00:00"  # UTC
-    open-pull-requests-limit: 10
+      time: "00:00" # UTC
+    open-pull-requests-limit: 3
+    versioning-strategy: increase
     commit-message:
       prefix: "chore"
       include: "scope"
-    groups:
-      major-updates:
-        update-types: ["major"]
-      minor-updates:
-        update-types: ["minor"]
-      patch-updates:
-        update-types: ["patch"]
 
   # GitHub Actions updates monthly
   - package-ecosystem: "github-actions"
@@ -26,7 +20,7 @@ updates:
       interval: "monthly"
       day: "wednesday"
       time: "01:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
 
     commit-message:
       prefix: "chore"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,14 +12,14 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: mansona/npm-lockfile-version@v1
         with:
           version: 3
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: 'npm'
+          cache: "npm"
       - name: Install dependencies
         run: |
           npm ci
@@ -36,11 +36,11 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: 'npm'
+          cache: "npm"
       - name: Install dependencies
         run: |
           npm ci
@@ -51,7 +51,8 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test:
     runs-on: ubuntu-latest
@@ -61,12 +62,12 @@ jobs:
         node-version: [20, 22, 24]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: "npm"
       - name: Install dependencies
         run: |
           npm ci
@@ -77,7 +78,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
@@ -101,10 +102,11 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
-      issues: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
       - name: Automerge Dependabot PRs if all checks have passed
         shell: bash
         env:


### PR DESCRIPTION
- Removed version grouping to prevent major updates from blocking CI
- Reduced PR limit to 3 to match previous group count
- Fix permission issue for Dependabot auto merge
- Add support for CODECOV_TOKEN
- Remove code coverage report upload as a blocking workflow step

#### Background

- The build is currently broken because of we recently set the main Branch as protected and CodeCov requires a token if the report is for a protected branch.
- The current Dependabot pull requests combine multiple packages if any based on their patch/minor/major version update.  That means a breaking change in a package in one of the groups can block all of the other packages from updating.
- There is misconfigure permission for Dependabot auto merge that will prevent the token for the github CLI to have insufficent permissions to squash and merge a pull request.

#### Solution
- Add support for CODECOV_TOKEN thru Github  secrets.  This PR also changes the upload step to not fail the entire job.  
NOTE: The codecov upload job for this PR seems to have [uploaded the coverage repot](https://app.codecov.io/github/sinonjs/samsam/pull/269).  However the job is stating "[Token of length 0 detected](https://github.com/sinonjs/samsam/actions/runs/16998570950/job/48195126867#step:6:232)".  I am not sure if the length reporting is a bug or something else is happening. It might be worth for one of the admins to check to make sure there is a valid CODECOV_TOKEN in the repo settings/secrets.

 _**For future discussion:**_ It might be worth revisiting the need for CodeCov and badge, considering that samsam is at 100% coverage and we are maintaining it at that level.

**_Side note:_** I did revert my fork to use the old curl upload of the coverage report, and that also failed stating "Token required - not valid tokenless upload"  https://github.com/YasharF/samsam/actions/runs/16998086539/job/48193522166#step:6:1

#### How to verify

- The workflow has been verified thru a run on my fork: https://github.com/YasharF/samsam/actions/runs/16998214202
- The updated workflow is also being executed as part of this PR's checks.
